### PR TITLE
refactor: 게시글 조회  쿠키 발급 로직 고도화

### DIFF
--- a/src/main/java/com/ll/gooHaeYu/domain/jobPost/jobPost/controller/JobPostController.java
+++ b/src/main/java/com/ll/gooHaeYu/domain/jobPost/jobPost/controller/JobPostController.java
@@ -18,6 +18,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
+import java.util.Arrays;
 import java.util.List;
 
 @Tag(name = "JobPost", description = "구인공고 API")
@@ -61,7 +62,7 @@ public class JobPostController {
         // 쿠키 없으면 조회수 증가하고 쿠키 생성
         if (!isJobPostAlreadyVisited) {
             jobPostService.increaseViewCount(id);
-            addOrUpdateViewedJobPostsCookie(response, id, VIEWED_JOB_POSTS_COOKIE);
+            addOrUpdateViewedJobPostsCookie(request, response, id, VIEWED_JOB_POSTS_COOKIE);
         }
 
         return  RsData.of(jobPostService.findById(id));
@@ -81,9 +82,29 @@ public class JobPostController {
     }
 
     // 쿠키 추가
-    private void addOrUpdateViewedJobPostsCookie(HttpServletResponse response, Long jobId, String cookieName) {
-        String cookieValue = "[" + jobId + "]";
-        CookieUtil.addCookie(response, cookieName, cookieValue, 24 * 60 * 60);
+    private void addOrUpdateViewedJobPostsCookie(HttpServletRequest request, HttpServletResponse response, Long jobId, String cookieName) {
+        // 쿠키에서 방문한 게시물 ID 목록 가져옴
+        Cookie viewCookie = Arrays.stream(request.getCookies() != null ? request.getCookies() : new Cookie[0])
+                .filter(cookie -> cookie.getName().equals(cookieName))
+                .findFirst()
+                .orElse(null);
+
+        // 가져온 목록에 현재 게시물 ID 추가
+        String newCookieValue;
+        if (viewCookie != null) {
+            String existingValue = viewCookie.getValue();
+            if (!existingValue.contains("[" + jobId + "]")) {
+                newCookieValue = existingValue + "[" + jobId + "]";
+            } else {
+                // 이미 방문한 게시물이면 쿠키 값 변경 x
+                return;
+            }
+        } else {
+            newCookieValue = "[" + jobId + "]";
+        }
+
+        // 새로운 쿠키 값 설정 or 기존 쿠키 업데이트
+        CookieUtil.addCookie(response, cookieName, newCookieValue, 24 * 60 * 60);
     }
 
     @PostMapping("/{id}/interest")

--- a/src/main/java/com/ll/gooHaeYu/domain/jobPost/jobPost/service/JobPostService.java
+++ b/src/main/java/com/ll/gooHaeYu/domain/jobPost/jobPost/service/JobPostService.java
@@ -12,6 +12,7 @@ import com.ll.gooHaeYu.domain.member.member.entity.type.Role;
 import com.ll.gooHaeYu.domain.member.member.repository.MemberRepository;
 import com.ll.gooHaeYu.domain.member.member.service.MemberService;
 import com.ll.gooHaeYu.global.exception.CustomException;
+import com.ll.gooHaeYu.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/ll/gooHaeYu/global/config/SecurityConfig.java
+++ b/src/main/java/com/ll/gooHaeYu/global/config/SecurityConfig.java
@@ -54,7 +54,7 @@ public class SecurityConfig {
                     requests
                             .requestMatchers("/api/member/socialLogin/**").permitAll()
                             .requestMatchers("/oauth2/authorization/**").permitAll() // OAuth 2.0 인증 엔드포인트에 대한 접근 허용
-                            .requestMatchers("/login", "/api/member/join", "api/token").permitAll()
+                            .requestMatchers("/login", "/api/member/login", "/api/member/join", "api/token").permitAll()
                             .requestMatchers(HttpMethod.GET, "/api/job-posts/{id:\\d+}", "/api/job-posts",
                                     "/api/post-comment/{postId}").permitAll()
                             .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()


### PR DESCRIPTION
## refatcoring 
- 다른 게시글 조회 시마다 쿠키를 새로 발급해서 덮어쓰기 하여 만료시간이 계속 늘어나는 문제점 발견
- 쿠키 목록에 게시글 id 추가 및 저장해서 계속 발급되는 문제점 해결

## 추가 예상되는 문제점
- 쿠키 저장용량 한계로 특정 게시글 조회 이후 저장이 안되는 문제 발생
 -> redis에 저장하여 관리하는것으로 refactoring 필요