### PR TITLE
Feature/front-3 구인공고 리스트, 단건조회 리팩토링

### DIFF
--- a/front/src/lib/types/api/v1/schema.d.ts
+++ b/front/src/lib/types/api/v1/schema.d.ts
@@ -232,18 +232,14 @@ export interface components {
       id: number;
       author: string;
       title: string;
-      body: string;
       location: string;
       /** Format: int64 */
       commentsCount: number;
       /** Format: int64 */
-      applicationCount: number;
-      /** Format: int64 */
-      interestsCount: number;
+      incrementViewCount: number;
       /** Format: date */
       deadLine?: string;
-      createdAt?: string;
-      closed?: boolean;
+      createdAt: string;
     };
     RsDataListJobPostDto: {
       resultCode?: string;
@@ -279,15 +275,23 @@ export interface components {
       id: number;
       author: string;
       title: string;
-      body: string;
       location: string;
+      /** Format: int64 */
+      commentsCount: number;
+      /** Format: int64 */
+      incrementViewCount: number;
+      /** Format: date */
+      deadLine?: string;
+      createdAt: string;
+      body: string;
+      /** Format: int64 */
+      applicationCount?: number;
+      /** Format: int64 */
+      interestsCount?: number;
       /** Format: int32 */
       minAge?: number;
       /** @enum {string} */
       gender?: "MALE" | "FEMALE" | "UNDEFINED";
-      /** Format: date */
-      deadLine?: string;
-      createdAt?: string;
       modifyAt?: string;
       closed?: boolean;
     };

--- a/front/src/routes/job-post/[id]/+page.svelte
+++ b/front/src/routes/job-post/[id]/+page.svelte
@@ -94,27 +94,37 @@
 
 {#await load()}
     <div>Loading...</div>
-{:then { data: jobPostDto }}
+{:then { data: jobPostDetailDto }}
     <div class="job-post-container">
-        <div class="id-box">No.{jobPostDto?.id}</div>
-        <div class="title-box">{jobPostDto?.title}</div>
+        <div class="id-box">No.{jobPostDetailDto?.id}</div>
+        <div class="title-box">{jobPostDetailDto?.title}</div>
         <div class="author-createdAt">
-            <p>{jobPostDto?.author}</p>
-            <p>등록일시 {jobPostDto?.createdAt}</p>
+            <p>{jobPostDetailDto?.author}</p>
+            <p>등록일시 {jobPostDetailDto?.createdAt}</p>
         </div>
-        <div class="content-box">{jobPostDto?.body}</div>
+        <div class="content-box">{jobPostDetailDto?.body}</div>
         <p>
-            {#if jobPostDto?.closed}
+            {#if jobPostDetailDto?.closed}
                 <span class="status-box">마감</span>
             {:else}
                 <span class="status-box">구인중</span>
             {/if}
         </p>
         <div class="info-box">
-            <div>위치: {jobPostDto?.location}</div>
-            <div>공고 마감: {jobPostDto?.deadLine}</div>
-            <div>지원 가능 최소 나이: {jobPostDto?.minAge}</div>
-            <div>성별 구분: {jobPostDto?.gender}</div>
+            <div>위치: {jobPostDetailDto?.location}</div>
+            <div>공고 마감: {jobPostDetailDto?.deadLine}</div>
+            <div>지원 가능 최소 나이: {jobPostDetailDto?.minAge}</div>
+            성별 구분: 
+            {#if jobPostDetailDto?.gender === 'MALE'}
+                남
+            {:else if jobPostDetailDto?.gender === 'FEMALE'}
+                여
+            {:else}
+                무관
+            {/if}
+            <div>최종 수정일자: {jobPostDetailDto?.modifyAt}</div>
+            <div>조회수: {jobPostDetailDto?.incrementViewCount}</div>
+            <div>관심 등록 수 : {jobPostDetailDto?.interestsCount}</div>
         </div>
     </div>
 {/await}

--- a/front/src/routes/job-post/list/+page.svelte
+++ b/front/src/routes/job-post/list/+page.svelte
@@ -66,6 +66,7 @@
                 <a href="/job-post/{jobPostDto.id}">{jobPostDto.title}</a>
                 <a href="/job-post/{jobPostDto.id}">{jobPostDto.author}</a>
                 <a href="/job-post/{jobPostDto.id}">{jobPostDto.createdAt}</a>
+                <a href="/job-post/{jobPostDto.id}">{jobPostDto.location}</a>
                 <a href="/job-post/{jobPostDto.id}">
                     {#if jobPostDto.closed}
                         마감

--- a/src/main/java/com/ll/gooHaeYu/domain/jobPost/jobPost/dto/JobPostDetailDto.java
+++ b/src/main/java/com/ll/gooHaeYu/domain/jobPost/jobPost/dto/JobPostDetailDto.java
@@ -3,6 +3,7 @@ package com.ll.gooHaeYu.domain.jobPost.jobPost.dto;
 import com.ll.gooHaeYu.domain.jobPost.jobPost.entity.Essential;
 import com.ll.gooHaeYu.domain.jobPost.jobPost.entity.JobPost;
 import com.ll.gooHaeYu.domain.jobPost.jobPost.entity.JobPostDetail;
+import com.ll.gooHaeYu.domain.member.member.entity.type.Gender;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
@@ -16,7 +17,8 @@ public class JobPostDetailDto extends AbstractJobPostDto{
     private String body;
     private long applicationCount;
     private long interestsCount;
-    private Essential essential;
+    private int minAge = 0;
+    private Gender gender = Gender.UNDEFINED;
     private boolean isClosed;
     private String modifyAt;
 
@@ -33,7 +35,8 @@ public class JobPostDetailDto extends AbstractJobPostDto{
                 .commentsCount(jobPost.getCommentsCount())
                 .applicationCount(jobPost.getApplicationCount())
                 .interestsCount(jobPost.getInterestsCount())
-                .essential(essential)
+                .gender(jobPostDetail.getEssential().getGender())
+                .minAge(jobPostDetail.getEssential().getMinAge())
                 .deadLine(jobPost.getDeadline())
                 .isClosed(jobPost.isClosed())
                 .createdAt(jobPost.getCreatedAt().format(formatter))

--- a/src/main/java/com/ll/gooHaeYu/domain/jobPost/jobPost/dto/JobPostDto.java
+++ b/src/main/java/com/ll/gooHaeYu/domain/jobPost/jobPost/dto/JobPostDto.java
@@ -1,6 +1,7 @@
 package com.ll.gooHaeYu.domain.jobPost.jobPost.dto;
 
 import com.ll.gooHaeYu.domain.jobPost.jobPost.entity.JobPost;
+import com.ll.gooHaeYu.standard.base.util.Ut;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 import org.springframework.data.domain.Page;
@@ -20,7 +21,7 @@ public class JobPostDto extends AbstractJobPostDto{
                 .id(jobPost.getId())
                 .author(jobPost.getMember().getUsername())
                 .title(jobPost.getTitle())
-                .location(jobPost.getLocation())
+                .location(Ut.addr.simplifyLocation(jobPost.getLocation()))
                 .commentsCount(jobPost.getCommentsCount())
                 .incrementViewCount(jobPost.getIncrementViewCount())
                 .deadLine(jobPost.getDeadline())

--- a/src/main/java/com/ll/gooHaeYu/domain/member/member/service/MemberService.java
+++ b/src/main/java/com/ll/gooHaeYu/domain/member/member/service/MemberService.java
@@ -97,6 +97,7 @@ public class MemberService {
         Member member = getMember(username);
 
         Member updatedMember = member.oauthDetailUpdate(form);
+        member.updateRole(Role.USER);
 
         return MemberDto.fromEntity(updatedMember);
     }

--- a/src/main/java/com/ll/gooHaeYu/global/initData/NotProd.java
+++ b/src/main/java/com/ll/gooHaeYu/global/initData/NotProd.java
@@ -74,6 +74,58 @@ public class NotProd {
 
                 memberService.login(loginForm);
 
+                JobPostForm.Register postRegister1 = JobPostForm.Register.builder()
+                        .title("주말 세탁물정리알바구해요 초보가능")
+                        .body("세탁물 단순 개비기입니다.\n" +
+                                "초보자도 가능해요.")
+                        .location("부산 동구 중앙대로 539")
+                        .deadLine(LocalDate.now().plusWeeks(2))
+                        .build();
+
+                jobPostService.writePost("testUser1", postRegister1);
+
+                JobPostForm.Register postRegister2 = JobPostForm.Register.builder()
+                        .title("과일 포장해 주실 분 구합니다")
+                        .body("5kg 과일박스 개인작업대로 들어올려 택배포장작업 또는 기타 포장작업 하는 업무 입니다 \n" +
+                                "개인작업대에서 과일 택배포장하시는거고 시간 잘갑니다\n" +
+                                "\n" +
+                                "02010 목요일 하루\n" +
+                                "\n" +
+                                "시간 8:00~12:00\n" +
+                                "일끝나고 입금")
+                        .location("경남 창원시 진해구 신항10로 98")
+                        .deadLine(LocalDate.now().plusWeeks(2))
+                        .minAge(20)
+                        .gender(Gender.UNDEFINED)
+                        .build();
+
+                jobPostService.writePost("testUser1", postRegister2);
+
+                JobPostForm.Register postRegister3 = JobPostForm.Register.builder()
+                        .title("촬영 현장 현장보조알바 구인 ")
+                        .body("유튜브 예능 촬영 현장 보조알바 분을 모집합니다.\n" +
+                                "약속 펑크 안내시는 책임감 있는 분들과 함께 일하게되는 기회가 되었으면 합니다.\n" +
+                                "\n" +
+                                "촬영 일정 : 02/10 14:30~22:00 / 이동 시간이 포함된 시간입니다.\n" +
+                                "\n" +
+                                "집합지 : 서울 성수역 인근\n" +
+                                "\n" +
+                                "담당 업무 : 촬영진행 보조\n" +
+                                "\n" +
+                                "페이 : 10만원\n" +
+                                "\n" +
+                                "\n" +
+                                "사무실에서 함께 짐을 챙겨 이동하고 촬영종료 후 정리하는 것이 주업무입니다.\n" +
+                                "\n" +
+                                "현장 스탭 안내에 따라 도움주시면 됩니다 :)\n")
+                        .location("서울 성동구 아차산로 100")
+                        .deadLine(LocalDate.now().plusDays(5))
+                        .minAge(20)
+                        .gender(Gender.MALE)
+                        .build();
+
+                jobPostService.writePost("testUser1", postRegister3);
+
                 IntStream.rangeClosed(1, 50).forEach(i -> {
                     JobPostForm.Register postRegister = JobPostForm.Register.builder()
                             .title("구인공고 제목" + i)

--- a/src/main/java/com/ll/gooHaeYu/standard/base/util/Ut.java
+++ b/src/main/java/com/ll/gooHaeYu/standard/base/util/Ut.java
@@ -3,6 +3,9 @@ package com.ll.gooHaeYu.standard.base.util;
 import com.ll.gooHaeYu.global.config.AppConfig;
 import lombok.SneakyThrows;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 public class Ut {
     public static class str {
         public static boolean isBlank(String str) {
@@ -18,6 +21,22 @@ public class Ut {
         @SneakyThrows
         public static void sleep(long millis) {
             Thread.sleep(millis);
+        }
+    }
+
+    public static class addr {
+        private static final Pattern LOCATION_PATTERN = Pattern.compile("^(서울|부산|대구|인천|광주|대전|울산|세종)|^(.*?[시도])\\s(.*?[시군구])");
+
+        public static String simplifyLocation(String location) {
+            Matcher matcher = LOCATION_PATTERN.matcher(location);
+            if (matcher.find()) {
+                for (int i = 1; i <= matcher.groupCount(); i++) {
+                    if (matcher.group(i) != null) {
+                        return matcher.group(i);
+                    }
+                }
+            }
+            return location; // 매치되는 패턴이 없다면 원본 문자열 반환
         }
     }
 


### PR DESCRIPTION
## 작업 내용

- 소셜 로그인 계정은 Role = USER가 되도록 설정

- NotProd에 샘플 데이터 추가

- jobPostDto 수정
  주소가 간단하게 보여지도록  jobPostDto 에 location 값을  "경기도 수원시 영통구 ~ "  -> "경기도 수원시" 와 같이 적용되도록 수정

- 프론트 구인공고 리스트, 상세페이지 수정