### PR TITLE
지원자 매칭, 공고에 대한 지원공고 리스트, 지원서 상세 페이지 추가, 마이페이지 수정

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -8,7 +8,8 @@
 			"name": "front",
 			"version": "0.0.1",
 			"dependencies": {
-				"openapi-fetch": "^0.8.2"
+				"openapi-fetch": "^0.8.2",
+				"sweetalert2": "^11.10.5"
 			},
 			"devDependencies": {
 				"@playwright/test": "^1.28.1",
@@ -4875,6 +4876,15 @@
 				"typescript": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/sweetalert2": {
+			"version": "11.10.5",
+			"resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-11.10.5.tgz",
+			"integrity": "sha512-q9eE3EKhMcpIDU/Xcz7z5lk8axCGkgxwK47gXGrrfncnBJWxHPPHnBVAjfsVXcTt8Yi8U6HNEcBRSu+qGeyFdA==",
+			"funding": {
+				"type": "individual",
+				"url": "https://github.com/sponsors/limonte"
 			}
 		},
 		"node_modules/tailwindcss": {

--- a/front/package.json
+++ b/front/package.json
@@ -42,6 +42,7 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"openapi-fetch": "^0.8.2"
+		"openapi-fetch": "^0.8.2",
+		"sweetalert2": "^11.10.5"
 	}
 }

--- a/front/src/lib/types/api/v1/schema.d.ts
+++ b/front/src/lib/types/api/v1/schema.d.ts
@@ -232,11 +232,14 @@ export interface components {
     };
     ApplicationDto: {
       /** Format: int64 */
-      id?: number;
-      author?: string;
+      id: number;
       /** Format: int64 */
-      postId?: number;
-      body?: string;
+      jobPostId: number;
+      jobPostName: string;
+      author: string;
+      /** Format: int64 */
+      postId: number;
+      body: string;
       /** Format: date-time */
       createdAt?: string;
       approve?: boolean;
@@ -326,8 +329,8 @@ export interface operations {
   modify: {
     parameters: {
       path: {
-        arg1: number;
-        arg2: number;
+        postId: number;
+        commentId: number;
       };
     };
     requestBody: {
@@ -451,8 +454,8 @@ export interface operations {
   approve: {
     parameters: {
       path: {
-        arg1: number;
-        arg2: number[];
+        postId: number;
+        applicationIds: number[];
       };
     };
     responses: {
@@ -655,10 +658,10 @@ export interface operations {
   socialLogin: {
     parameters: {
       query: {
-        arg0: string;
+        redirectUrl: string;
       };
       path: {
-        arg1: string;
+        providerTypeCode: string;
       };
     };
     responses: {
@@ -674,7 +677,7 @@ export interface operations {
   findByPostId: {
     parameters: {
       path: {
-        arg0: number;
+        postId: number;
       };
     };
     responses: {
@@ -770,7 +773,7 @@ export interface operations {
   getList: {
     parameters: {
       path: {
-        arg1: number;
+        postId: number;
       };
     };
     responses: {

--- a/front/src/routes/applications/detail/[id]/+page.svelte
+++ b/front/src/routes/applications/detail/[id]/+page.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+	import rq from '$lib/rq/rq.svelte';
+	import Swal from 'sweetalert2'; // SweetAlert2를 사용하여 예/아니오 확인 메시지 표시
+
+	async function loadApplication() {
+		const { data } = await rq.apiEndPoints().GET('/api/applications/{id}', {
+			params: {
+				path: {
+					id: parseInt($page.params.id)
+				}
+			}
+		});
+
+		return data!.data!;
+	}
+
+    function formatDate(dateString) {
+    const options = { year: '2-digit', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' };
+    return new Date(dateString).toLocaleString('ko-KR', options);
+    }
+
+	async function approve(jobPostId, applicationId) {
+
+        // SweetAlert2를 사용하여 사용자에게 승인 확인 요청
+        const result = await Swal.fire({
+        title: '승인하시겠습니까?',
+        text: "이 작업은 다시 되돌릴 수 없습니다.",
+        icon: 'warning',
+        showCancelButton: true,
+        confirmButtonColor: '#3085d6',
+        cancelButtonColor: '#d33',
+        confirmButtonText: 'OK'
+        });
+
+        if (result.isConfirmed) {
+            await rq.apiEndPoints().PUT(`/api/employ/${jobPostId}/${applicationId}`, {
+            headers: { 'Content-Type': 'application/json' }
+        });
+        Swal.fire('해당 지원서가 승인되었습니다.', '완료');
+        window.location.reload(); // 승인 후 페이지 새로고침
+        }
+  }
+</script>
+
+{#await loadApplication() then application}
+  <div class="container mx-auto p-4">
+    <div class="card bg-base-100 shadow-xl rounded-lg p-5">
+      <h2 class="card-title text-xl font-bold mb-4">지원서 상세 정보</h2>
+      <p class="mb-2"><strong>지원서 번호:</strong> {application.id}</p>
+      <p class="mb-2"><strong>지원자:</strong> {application.author}</p>
+      <p class="mb-2"><strong>내용:</strong> {application.body}</p>
+      <p class="mb-2"><strong>제출일:</strong> {formatDate(application.createdAt)}</p>
+      <p class="mb-2">
+        <strong>승인 상태:</strong>
+        {#if application.approve === true}
+            <span class="badge badge-success">승인</span>
+        {:else if application.approve === false}
+            <span class="badge badge-error">미승인</span>
+        {:else}
+            <span class="badge badge-warning">진행중</span>
+        {/if}
+    </p>
+    <!-- 승인 버튼 -->
+    {#if application.approve == null}
+        <div class="text-center mt-2">
+            <button class="btn btn-outline btn-info" on:click={() => approve(application.jobPostId, application.id)}>승인하기</button>
+        </div>
+    {/if}
+    <!-- 승인완료 버튼 -->
+    {#if application.approve == true}
+        <div class="text-center mt-2">
+            <button class="btn btn-disabled" disabled>승인완료</button>
+        </div>
+    {/if}
+</div>
+</div>
+{:catch error}
+  <p class="text-error">데이터를 로드하는 동안 오류가 발생했습니다: {error.message}</p>
+{/await}

--- a/front/src/routes/applications/list/[id]/+page.svelte
+++ b/front/src/routes/applications/list/[id]/+page.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+  import { page } from '$app/stores';
+  import rq from '$lib/rq/rq.svelte';
+
+  async function loadApplications() {
+      const { data } = await rq.apiEndPoints().GET('/api/employ/{postId}', {
+          params: {
+              path: {
+                  postId: parseInt($page.params.id)
+              }
+          }
+      });
+      
+      return data;
+  }
+
+  function formatDate(dateString) {
+    const options = { year: '2-digit', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' };
+    return new Date(dateString).toLocaleString('ko-KR', options);
+  }
+
+  function summarizeBody(body) {
+    return body.length > 10 ? `${body.slice(0, 10)}...` : body;
+  }
+</script>
+
+{#await loadApplications()}
+  <p class="text-center">Loading...</p>
+{:then { data: applications }}
+  {#if applications.length > 0}
+    <div class="flex flex-col items-center">
+      <ul class="w-full max-w-4xl">
+        {#each applications ?? [] as application, index}
+          <li class="card bg-base-100 shadow-xl m-4">
+            <div class="card-body">
+              <h2 class="card-title">
+                <a href={`/applications/detail/${application.id}`} class="link link-hover">
+                  지원서 번호 #{index + 1}
+                </a>
+              </h2>
+              <p>지원자 ID: {application.author}</p>
+              <p>지원내용: {summarizeBody(application.body)}</p>
+              <p>지원일: {formatDate(application.createdAt)}</p>
+              <p>승인 여부: 
+                {#if application.approve === true}
+                  <span class="badge badge-success">승인</span>
+                {:else if application.approve === false}
+                  <span class="badge badge-error">미승인</span>
+                {:else}
+                  <span class="badge badge-warning">진행중</span>
+                {/if}
+              </p>
+            </div>
+          </li>
+        {/each}
+      </ul>
+    </div>
+  {:else}
+    <div class="text-center">해당 공고에 아직 지원자가 없습니다.</div>
+  {/if}
+  {:catch error}
+  <p>Error loading applications: {error.message}</p>
+{/await}

--- a/front/src/routes/member/me/+page.svelte
+++ b/front/src/routes/member/me/+page.svelte
@@ -33,6 +33,10 @@
 		const { data } = await rq.apiEndPoints().GET('/api/member/myinterest', {});
 		return data;
 	}
+
+	function summarizeBody(body) {
+    return body.length > 10 ? `${body.slice(0, 10)}...` : body;
+    }
 </script>
 
 <div class="flex items-center justify-center min-h-screen bg-base-100">
@@ -99,8 +103,8 @@
 									<ul>
 										{#each jobPostDtoList ?? [] as jobPostDto, index}
 											<li>
-												<a href="/job-post/{jobPostDto.id}">no.{index + 1}</a>
-												<a href="/job-post/{jobPostDto.id}">{jobPostDto.title}</a>
+												<a href="/applications/list/{jobPostDto.id}">no.{index + 1}</a>   
+												<a href="/applications/list/{jobPostDto.id}">{jobPostDto.title}</a>    
 											</li>
 										{/each}
 									</ul>
@@ -122,8 +126,8 @@
 									<ul>
 										{#each applicationDtoList ?? [] as applicationDto}
 											<li>
-												<a href="/job-post/{applicationDto.postId}">공고{applicationDto.postId}</a>
-												<a href="/job-post/{applicationDto.postId}">{applicationDto.body}</a>
+												<a href="/applications/detail/{applicationDto.id}">{applicationDto.jobPostName}</a>
+												<a href="/applications/detail/{applicationDto.id}">{summarizeBody(applicationDto.body)}</a>
 											</li>
 										{/each}
 									</ul>

--- a/src/main/java/com/ll/gooHaeYu/domain/application/application/dto/ApplicationDto.java
+++ b/src/main/java/com/ll/gooHaeYu/domain/application/application/dto/ApplicationDto.java
@@ -1,6 +1,7 @@
 package com.ll.gooHaeYu.domain.application.application.dto;
 
 import com.ll.gooHaeYu.domain.application.application.entity.Application;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,9 +12,17 @@ import java.util.List;
 @Getter
 public class ApplicationDto {
 
+    @NotNull
     private Long id;
+    @NotNull
+    private Long jobPostId;
+    @NotNull
+    private String jobPostName;
+    @NotNull
     private String author;
+    @NotNull
     private Long postId;
+    @NotNull
     private String body;
     private LocalDateTime createdAt;
     private Boolean approve;
@@ -21,6 +30,8 @@ public class ApplicationDto {
     public static ApplicationDto fromEntity(Application application) {
         return ApplicationDto.builder()
                 .id(application.getId())
+                .jobPostId(application.getJobPostDetail().getJobPost().getId())
+                .jobPostName(application.getJobPostDetail().getJobPost().getTitle())
                 .author(application.getMember().getUsername())
                 .postId(application.getJobPostDetail().getJobPost().getId())
                 .body(application.getBody())

--- a/src/main/java/com/ll/gooHaeYu/domain/jobPost/jobPost/dto/JobPostForm.java
+++ b/src/main/java/com/ll/gooHaeYu/domain/jobPost/jobPost/dto/JobPostForm.java
@@ -28,7 +28,6 @@ public class JobPostForm {
         private Gender gender = Gender.UNDEFINED;
 
         private LocalDate deadLine;
-//        private LocalDateTime deadLine;
     }
 
     @Builder

--- a/src/main/java/com/ll/gooHaeYu/global/config/SecurityConfig.java
+++ b/src/main/java/com/ll/gooHaeYu/global/config/SecurityConfig.java
@@ -22,6 +22,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import static org.springframework.boot.autoconfigure.security.servlet.PathRequest.toH2Console;
 
 @Configuration
 @EnableWebSecurity // 기본 웹 보안 활성화
@@ -37,7 +38,7 @@ public class SecurityConfig {
     @Bean
     public WebSecurityCustomizer configure() {
         return (web) -> web.ignoring()
-                .requestMatchers("/h2-console/**")
+                .requestMatchers(toH2Console())
                 .requestMatchers("/static/**");
     }
 
@@ -48,6 +49,8 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .csrf(AbstractHttpConfigurer::disable)
                 .cors()
+                .and()
+                .headers().frameOptions().disable()
                 .and()
                 .authorizeHttpRequests(requests -> {
                     requests

--- a/src/main/java/com/ll/gooHaeYu/global/initData/NotProd.java
+++ b/src/main/java/com/ll/gooHaeYu/global/initData/NotProd.java
@@ -79,6 +79,7 @@ public class NotProd {
                         .body("세탁물 단순 개비기입니다.\n" +
                                 "초보자도 가능해요.")
                         .location("부산 동구 중앙대로 539")
+                        .gender(Gender.UNDEFINED)
                         .deadLine(LocalDate.now().plusWeeks(2))
                         .build();
 
@@ -133,6 +134,7 @@ public class NotProd {
                             .location("서울 광진구 천호대로124길")
                             .deadLine(LocalDate.now().plusWeeks(2))
                             .minAge(20)
+                            .gender(Gender.UNDEFINED)
                             .build();
 
                     jobPostService.writePost("testUser1", postRegister);

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -27,4 +27,4 @@ logging:
     org.hibernate.orm.jdbc.extract: TRACE
     org.springframework.transaction.interceptor: TRACE
 app:
-  init-run: true
+  init-run: false


### PR DESCRIPTION
## 작업내용
<br>

### 공고에 대한 지원서 목록 페이지 추가
- 마이페이지 - 내 공고를 누르면 접근

<br>

### 지원서 상세페이지 추가
- '승인 상태'로 승인 여부를 알 수 있도록 설정
- 지원서 승인을 할 수 있는 버튼 추가
- 승인이 되면 승인완료 버튼이 보이도록 설정
- 미승인된 지원서는 승인하기 버튼이 보이지 않도록 설정

<br>

### 마이페이지 수정 
- 내가 작성했던 지원서 목록에서 지원공고 명과 간략한 내용이 보여지도록 수정
- 지원서 목록에 있는 지원서를 누르면 지원서 상세 정보로 이동하도록 변경
- 내 공고 목록에서 공고를 누르면, 해당 공고의 지원서들을 볼 수 있도록 수정

<br>

### ApplicationDto 수정
- 유효성검사,  jobPostId, jobPostName 필드 추가

<br>

### NotProd 수정
- 성별에 null 값이 들어가지 않도록 수정
<br>