### PR TITLE
공고 조기마감 프론트 구현, 디자인 수정

### DIFF
--- a/front/src/lib/types/api/v1/schema.d.ts
+++ b/front/src/lib/types/api/v1/schema.d.ts
@@ -34,6 +34,7 @@ export interface paths {
     delete: operations["deleteJobPost"];
   };
   "/api/job-posts/{id}/closing": {
+    /** 조기 마감 */
     put: operations["postEarlyClosing"];
   };
   "/api/job-posts/a": {
@@ -295,9 +296,10 @@ export interface components {
       incrementViewCount: number;
       /** Format: int64 */
       interestsCount: number;
+      createdAt: string;
+      employed?: boolean;
       /** Format: date */
       deadLine?: string;
-      createdAt: string;
       closed?: boolean;
     };
     RsDataListJobPostDto: {
@@ -346,9 +348,10 @@ export interface components {
       incrementViewCount: number;
       /** Format: int64 */
       interestsCount: number;
+      createdAt: string;
+      employed?: boolean;
       /** Format: date */
       deadLine?: string;
-      createdAt: string;
       body: string;
       /** Format: int64 */
       applicationCount?: number;
@@ -357,7 +360,6 @@ export interface components {
       /** @enum {string} */
       gender?: "MALE" | "FEMALE" | "UNDEFINED";
       modifyAt?: string;
-      employed?: boolean;
       interestedUsernames?: string[];
       closed?: boolean;
     };
@@ -553,6 +555,7 @@ export interface operations {
       };
     };
   };
+  /** 조기 마감 */
   postEarlyClosing: {
     parameters: {
       path: {
@@ -562,7 +565,9 @@ export interface operations {
     responses: {
       /** @description OK */
       200: {
-        content: never;
+        content: {
+          "*/*": components["schemas"]["RsDataVoid"];
+        };
       };
     };
   };
@@ -782,7 +787,9 @@ export interface operations {
     responses: {
       /** @description OK */
       200: {
-        content: never;
+        content: {
+          "*/*": components["schemas"]["RsDataVoid"];
+        };
       };
     };
   };

--- a/front/src/lib/types/api/v1/schema.d.ts
+++ b/front/src/lib/types/api/v1/schema.d.ts
@@ -318,6 +318,7 @@ export interface components {
       /** Format: int64 */
       postId: number;
       body: string;
+      name: string;
       /** Format: date */
       birth: string;
       phone: string;

--- a/front/src/routes/+page.svelte
+++ b/front/src/routes/+page.svelte
@@ -52,6 +52,10 @@
 										<div class="flex flex-col items-center">
 											{#if post.closed}
 												<div class="badge badge-neutral">마감</div>
+											{:else if post.employed}
+												<div class="badge badge-ghost my-1">구인완료</div>
+												<div class="text-xs text-gray-500">마감기한</div>
+												<div class="text-xs text-gray-500">{post.deadLine}</div>
 											{:else}
 												<div class="badge badge-primary my-1">구인중</div>
 												<div class="text-xs text-gray-500">마감기한</div>

--- a/front/src/routes/applications/detail/[id]/+page.svelte
+++ b/front/src/routes/applications/detail/[id]/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/stores';
 	import rq from '$lib/rq/rq.svelte';
-	import Swal from 'sweetalert2'; // SweetAlert2를 사용하여 예/아니오 확인 메시지 표시
 
 	async function loadApplication() {
 		const { data } = await rq.apiEndPoints().GET('/api/applications/{id}', {
@@ -38,23 +37,17 @@
 	}
 
 	async function approve(jobPostId, applicationId) {
-		// SweetAlert2를 사용하여 사용자에게 승인 확인 요청
-		const result = await Swal.fire({
-			title: '승인하시겠습니까?',
-			text: '이 작업은 다시 되돌릴 수 없습니다.',
-			icon: 'warning',
-			showCancelButton: true,
-			confirmButtonColor: '#3085d6',
-			cancelButtonColor: '#d33',
-			confirmButtonText: 'OK'
+		const response = await rq.apiEndPoints().PATCH(`/api/employ/${jobPostId}/${applicationId}`, {
+			headers: { 'Content-Type': 'application/json' }
 		});
 
-		if (result.isConfirmed) {
-			await rq.apiEndPoints().PATCH(`/api/employ/${jobPostId}/${applicationId}`, {
-				headers: { 'Content-Type': 'application/json' }
-			});
-
-			window.location.reload(); // 승인 후 페이지 새로고침
+		if (response.data?.statusCode === 204) {
+			alert('지원서가 승인되었습니다.');
+			location.reload();
+		} else if (response.data?.msg == 'CUSTOM_EXCEPTION') {
+			alert(response.data?.data?.message);
+		} else {
+			alert('지원서 승인에 실패했습니다. 다시 시도해주세요.');
 		}
 	}
 

--- a/front/src/routes/applications/detail/[id]/+page.svelte
+++ b/front/src/routes/applications/detail/[id]/+page.svelte
@@ -85,21 +85,39 @@
 {#await loadApplication() then application}
 	<div class="container mx-auto p-4">
 		<div class="card bg-base-100 shadow-xl rounded-lg p-5">
-			<h2 class="card-title text-xl font-bold mb-4">지원서 상세 정보</h2>
-			<p class="mb-2"><strong>지원서 번호:</strong> {application.id}</p>
-			<p class="mb-2"><strong>지원자:</strong> {application.author}</p>
-			<p class="mb-2"><strong>지원자 나이:</strong> {calculateAge(application.birth)}</p>
-			<p class="mb-2"><strong>지원자 연락처:</strong> {application.phone}</p>
-			<p class="mb-2"><strong>지원자 주소:</strong> {application.location}</p>
-			<p class="mb-2"><strong>제출일:</strong> {formatDate(application.createdAt)}</p>
+			<div class="flex items-center mb-4">
+				<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 mr-2">
+					<path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
+				</svg>
+				<h2 class="card-title text-xl font-bold">지원서 상세 정보</h2>
+			</div>
+
+			<div class="bg-white rounded-md mb-4">
+				<div class="px-4 py-2 border-b border-gray-200">
+					<h3 class="text-lg font-semibold mb-2">지원자 정보</h3>
+				</div>
+
+				<div class="px-4 py-2 space-y-2">
+					<p><strong>아이디:</strong> {application.author}</p>
+					<p><strong>이름:</strong> {application.name}</p>
+					<p><strong>나이:</strong> {calculateAge(application.birth)}</p>
+					<p><strong>연락처:</strong> {application.phone}</p>
+					<p><strong>주소:</strong> {application.location}</p>
+				</div>
+			</div>
+			<hr class="my-4 border-t border-gray-300 opacity-50">
 			<div class="mb-2">
-				<strong>내용:</strong>
-				<div class="p-3 bg-gray-100 rounded overflow-auto" style="max-height: 200px;">
+				<strong>작성 내용</strong>
+				<div class="p-3 bg-gray-100 rounded overflow-auto mt-1" style="max-height: 200px;">
 					{application.body}
 				</div>
 			</div>
 
-			<p class="mb-2">
+			<p class="mb-2 mt-3"><strong>지원서 번호:</strong> {application.id}</p>
+      	    <p class="mb-2"><strong>제출일:</strong> {formatDate(application.createdAt)}</p>
+
+
+			<p class="mb-2 mt-2">
 				<strong>승인 상태:</strong>
 				{#if application.approve === true}
 					<span class="badge badge-success">승인</span>

--- a/front/src/routes/job-post/[id]/+page.svelte
+++ b/front/src/routes/job-post/[id]/+page.svelte
@@ -232,7 +232,6 @@
 					<div class="text-sm">조회 :</div>
 					<div class="text-sm mx-2">{jobPostDetailDto?.incrementViewCount}</div>
 				</div>
-
 			</div>
 			<div class="p-4 mt-4 text-gray-700 bg-white rounded-lg shadow border border-gray-200">
 				<div class="whitespace-pre-line">{jobPostDetailDto?.body}</div>

--- a/front/src/routes/job-post/list/+page.svelte
+++ b/front/src/routes/job-post/list/+page.svelte
@@ -116,6 +116,10 @@
 										<div class="flex flex-col items-center">
 											{#if post.closed}
 												<div class="badge badge-neutral">마감</div>
+											{:else if post.employed}
+												<div class="badge badge-ghost my-1">구인완료</div>
+												<div class="text-xs text-gray-500">마감기한</div>
+												<div class="text-xs text-gray-500">{post.deadLine}</div>
 											{:else}
 												<div class="badge badge-primary my-1">구인중</div>
 												<div class="text-xs text-gray-500">마감기한</div>

--- a/src/main/java/com/ll/gooHaeYu/domain/application/application/dto/ApplicationDto.java
+++ b/src/main/java/com/ll/gooHaeYu/domain/application/application/dto/ApplicationDto.java
@@ -28,6 +28,8 @@ public class ApplicationDto {
     @NotNull
     private String body;
     @NotNull
+    private String name;
+    @NotNull
     private LocalDate birth;
     @NotNull
     private String phone;
@@ -45,6 +47,7 @@ public class ApplicationDto {
                 .author(application.getMember().getUsername())
                 .postId(application.getJobPostDetail().getJobPost().getId())
                 .body(application.getBody())
+                .name(application.getMember().getName())
                 .birth(application.getMember().getBirth())
                 .phone(application.getMember().getPhoneNumber())
                 .location(application.getMember().getLocation())

--- a/src/main/java/com/ll/gooHaeYu/domain/jobPost/employ/controller/EmployController.java
+++ b/src/main/java/com/ll/gooHaeYu/domain/jobPost/employ/controller/EmployController.java
@@ -6,7 +6,6 @@ import com.ll.gooHaeYu.global.rsData.RsData;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
@@ -28,11 +27,11 @@ public class EmployController {
 
     @PatchMapping("/{applicationIds}")
     @Operation(summary = "지원서 승인")
-    public ResponseEntity<Void> approve(Authentication authentication,
+    public RsData<Void> approve(Authentication authentication,
                         @PathVariable Long postId,
                         @PathVariable List<Long> applicationIds) {
         employService.approve(authentication.getName(), postId, applicationIds);
 
-        return ResponseEntity.noContent().build();
+        return RsData.of("204", "NO_CONTENT");
     }
 }

--- a/src/main/java/com/ll/gooHaeYu/domain/jobPost/jobPost/controller/JobPostController.java
+++ b/src/main/java/com/ll/gooHaeYu/domain/jobPost/jobPost/controller/JobPostController.java
@@ -154,12 +154,14 @@ public class JobPostController {
     }
 
     @PutMapping("/{id}/closing")
-    public ResponseEntity<Void> postEarlyClosing(@AuthenticationPrincipal MemberDetails memberDetails,
+    @Operation(summary = "조기 마감")
+    public RsData<Void> postEarlyClosing(@AuthenticationPrincipal MemberDetails memberDetails,
                                                  @PathVariable(name = "id") Long id) {
         jobPostService.postEarlyClosing(memberDetails.getUsername(), id);
 
-        return ResponseEntity.noContent().build();
+        return RsData.of("204", "NO_CONTENT");
     }
+
     @PutMapping("/a")
     public ResponseEntity<Void> a(){
         jobPostService.checkAndCloseExpiredJobPosts();

--- a/src/main/java/com/ll/gooHaeYu/domain/jobPost/jobPost/dto/AbstractJobPostDto.java
+++ b/src/main/java/com/ll/gooHaeYu/domain/jobPost/jobPost/dto/AbstractJobPostDto.java
@@ -23,8 +23,9 @@ public class AbstractJobPostDto {
     private long incrementViewCount;
     @NotNull
     private long interestsCount;
-    private LocalDate deadLine;
     @NotNull
     private String createdAt;
 
+    private boolean employed;
+    private LocalDate deadLine;
 }

--- a/src/main/java/com/ll/gooHaeYu/domain/jobPost/jobPost/dto/JobPostDetailDto.java
+++ b/src/main/java/com/ll/gooHaeYu/domain/jobPost/jobPost/dto/JobPostDetailDto.java
@@ -23,7 +23,6 @@ public class JobPostDetailDto extends AbstractJobPostDto{
     private Gender gender = Gender.UNDEFINED;
     private boolean isClosed;
     private String modifyAt;
-    private boolean employed;
     private List<String> interestedUsernames;
 
     public static JobPostDetailDto fromEntity(JobPost jobPost, JobPostDetail jobPostDetail, Essential essential) {

--- a/src/main/java/com/ll/gooHaeYu/domain/jobPost/jobPost/dto/JobPostDto.java
+++ b/src/main/java/com/ll/gooHaeYu/domain/jobPost/jobPost/dto/JobPostDto.java
@@ -26,6 +26,7 @@ public class JobPostDto extends AbstractJobPostDto{
                 .commentsCount(jobPost.getCommentsCount())
                 .incrementViewCount(jobPost.getIncrementViewCount())
                 .interestsCount(jobPost.getInterestsCount())
+                .employed(jobPost.isEmployed())
                 .deadLine(jobPost.getDeadline())
                 .isClosed(jobPost.isClosed())
                 .createdAt(jobPost.getCreatedAt().format(formatter))


### PR DESCRIPTION
## 작업내용

#### 프론트 조기마감 기능 설정, 공고 상세페이지 수정
- 조기마감 버튼을 누르면 조기마감 처리되어 새로고침 후 반영
- 공고 상세 페이지에 지원서 목록으로 이동할 수 있는 버튼 추가 (공고글 작성자에게만 보이도록 설정)

#### 공고 목록 페이지에서 공고글 상태에 '구인완료' 추가

#### DTO 에서 employed 관련 수정
- JobPostDetailDto 에서 AbstractJobPostDto 로 이동

#### 지원서 승인 알림창 제거 
- SweetAlert2 알림창 제거
- 기존의 알림 메시지가 뜨도록 변경

#### 지원서 상세정보 페이지 디자인 수정 
- 지원자 정보에 이름 항목도 추가

#### API 반환값 형태를 RsData로 변경 
- 프론트에서 쉽게 예외처리를 하기 위해 변경

<br>
