### PR TITLE
Feature/individual-payment-cancel 지급 방식이 개인 지급인 알바 취소 처리 구현, 캐시로그 리팩토링

### DIFF
--- a/front/src/routes/applications/detail/[id]/+page.svelte
+++ b/front/src/routes/applications/detail/[id]/+page.svelte
@@ -48,6 +48,22 @@
 		}
 	}
 
+	async function cancelRequest(applicationId: number) {
+		const response = await rq
+			.apiEndPoints()
+			.PATCH(`/api/jobs/individual/no-work/${applicationId}`, {});
+
+		if (response.data?.statusCode === 204) {
+			rq.msgInfo('취소 완료되었습니다.');
+			location.reload();
+		} else if (response.data?.msg === 'CUSTOM_EXCEPTION') {
+			const customErrorMessage = response.data?.data?.message;
+			rq.msgError(customErrorMessage);
+		} else {
+			rq.msgError('요청 중 오류가 발생했습니다.');
+		}
+	}
+
 	function formatDate(dateString) {
 		const options = {
 			year: '2-digit',
@@ -78,7 +94,7 @@
 		rq.goTo(`/payment/pay/${$page.params.id}/${wages}`);
 	}
 
-	function goToCancelPage() {
+	function goToPayCancelPage() {
 		rq.goTo(`/payment/cancel/${$page.params.id}`);
 	}
 </script>
@@ -169,7 +185,16 @@
 								class="btn btn-active btn-primary btn-sm"
 								on:click={() => completeJobManually(application.id)}>알바 완료</button
 							>
-							<button class="btn btn-sm" on:click={() => goToCancelPage()}>급여 결제 취소</button>
+							{#if application.wageStatus == '급여 결제 완료'}
+								<button class="btn btn-sm" on:click={() => goToPayCancelPage()}
+									>급여 결제 취소</button
+								>
+							{/if}
+							{#if application.wageStatus == '지원서 승인'}
+								<button class="btn btn-sm" on:click={() => cancelRequest(application.id)}
+									>취소 요청</button
+								>
+							{/if}
 						</div>
 					{/if}
 				</div>

--- a/front/src/routes/payment/success/+page.svelte
+++ b/front/src/routes/payment/success/+page.svelte
@@ -93,7 +93,7 @@
 		<div class="mt-6">
 			<button
 				class="btn bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded"
-				on:click={() => rq.goTo('/')}
+				on:click={() => rq.goTo('/applications/detail/' + data.applicationId)}
 				>확인
 			</button>
 		</div>

--- a/src/main/java/com/ll/gooHaeYu/domain/application/application/entity/type/WageStatus.java
+++ b/src/main/java/com/ll/gooHaeYu/domain/application/application/entity/type/WageStatus.java
@@ -10,6 +10,7 @@ public enum WageStatus {
 
     // 개인 지급
     APPLICATION_APPROVED("지원서 승인"),
+    WORK_INCOMPLETE_NO_PAYMENT("작업 미완료로 인한 취소"),
     WAGE_PAID("급여 지급 완료"),
 
     // 서비스 결제

--- a/src/main/java/com/ll/gooHaeYu/domain/jobPost/employ/controller/WorkCompletionController.java
+++ b/src/main/java/com/ll/gooHaeYu/domain/jobPost/employ/controller/WorkCompletionController.java
@@ -6,24 +6,35 @@ import com.ll.gooHaeYu.global.security.MemberDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-@Slf4j
 @Tag(name = "WorkCompletion", description = "알바완료 처리 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/jobs/complete")
+@RequestMapping("/api/jobs")
 public class WorkCompletionController {
     private final WorkCompletionService workCompletionService;
 
-    @PatchMapping ("/{applicationId}/manually")
+    @PatchMapping ("/complete/{applicationId}/manually")
     @Operation(summary = "구인자가 수동으로 알바완료 처리")
     public RsData<Void> completeJobManually(@AuthenticationPrincipal MemberDetails memberDetails,
-                                         @PathVariable (name = "applicationId") Long applicationId) {
+                                            @PathVariable (name = "applicationId") Long applicationId) {
 
         workCompletionService.completeJobManually(memberDetails.getUsername(), applicationId);
+
+        return RsData.of("204", "NO_CONTENT");
+    }
+
+    @PatchMapping("/individual/no-work/{applicationId}")
+    @Operation(summary = "개인 지급 알바 미완료 처리")
+    public RsData<Void> cancelIndividualNoWork(@AuthenticationPrincipal MemberDetails memberDetails,
+                                               @PathVariable (name = "applicationId") Long applicationId) {
+
+        workCompletionService.cancelByIndividualPayment(memberDetails.getUsername(), applicationId);
 
         return RsData.of("204", "NO_CONTENT");
     }

--- a/src/main/java/com/ll/gooHaeYu/domain/payment/cashLog/eventListener/CashLogEventListener.java
+++ b/src/main/java/com/ll/gooHaeYu/domain/payment/cashLog/eventListener/CashLogEventListener.java
@@ -5,7 +5,6 @@ import com.ll.gooHaeYu.global.event.cashLog.CashLogEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -14,6 +13,6 @@ public class CashLogEventListener {
 
     @EventListener
     public void creatCashLogEvent(CashLogEvent event) {
-        cashLogService.createCashLog(event.getApplication());
+        cashLogService.createCashLogOnSettled(event.getApplication());
     }
 }

--- a/src/main/java/com/ll/gooHaeYu/domain/payment/cashLog/service/CashLogService.java
+++ b/src/main/java/com/ll/gooHaeYu/domain/payment/cashLog/service/CashLogService.java
@@ -8,56 +8,20 @@ import com.ll.gooHaeYu.domain.payment.cashLog.repository.CashLogRepository;
 import com.ll.gooHaeYu.domain.payment.payment.dto.success.PaymentSuccessDto;
 import com.ll.gooHaeYu.domain.payment.payment.entity.Payment;
 import com.ll.gooHaeYu.domain.payment.payment.entity.type.PayStatus;
-import com.ll.gooHaeYu.domain.payment.payment.entity.type.PayTypeFee;
+import com.ll.gooHaeYu.domain.payment.payment.service.PaymentCalculationService;
 import com.ll.gooHaeYu.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Arrays;
-
-import static com.ll.gooHaeYu.global.exception.ErrorCode.NO_ENUM_CONSTANT_FOUND;
 import static com.ll.gooHaeYu.global.exception.ErrorCode.POST_NOT_EXIST;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-@Slf4j
 public class CashLogService {
+    private final PaymentCalculationService paymentCalculationService;
     private final CashLogRepository cashLogRepository;
-
-    // 토스페이먼츠 결제 부과세 10% 반환
-    public long getVat(long totalAmount) {
-        return (int) (totalAmount * 0.1);
-    }
-
-    // 결제 수수료 반환
-    public long getPaymentFee(PayStatus payStatus, long totalAmount) {
-        PayTypeFee payTypeFee = matchPayTypeFee(payStatus);
-
-        double feePercentage = payTypeFee.getFeePercentage();
-        int transactionFee = payTypeFee.getTransactionFee();
-
-        return (int) ((totalAmount * feePercentage / 100.0) + transactionFee);
-    }
-
-    private PayTypeFee matchPayTypeFee(PayStatus payStatus) {
-        return Arrays.stream(PayTypeFee.values())
-                .filter(payTypeFee -> payTypeFee.getTypeName().equals(payStatus.getDescription()))
-                .findFirst()
-                .orElseThrow(() -> new CustomException(NO_ENUM_CONSTANT_FOUND));   // 매칭되는 PayTypeFee가 없는 경우
-    }
-
-    // 부가세와 결제 수수료의 합 반환
-    public long getTotalTaxAndFees(PayStatus payStatus, long totalAmount) {
-        return getVat(totalAmount) + getPaymentFee(payStatus, totalAmount);
-    }
-
-    // 순금액 반환
-    public long getNetAmount (PayStatus payStatus, long totalAmount) {
-        return totalAmount - getTotalTaxAndFees(payStatus, totalAmount);
-    }
 
     public CashLogDto findByApplicationId(Long id) {
         CashLog cashLog = findByApplicationIdAndValidate(id);
@@ -70,21 +34,21 @@ public class CashLogService {
                 .orElseThrow(() -> new CustomException(POST_NOT_EXIST));
     }
 
-    @Transactional
-    public void addCashLog(CashLog cashLog) {
+    private void addCashLog(CashLog cashLog) {
         cashLogRepository.save(cashLog);
     }
 
-    public void createCashLog(Application application) {
+    @Transactional
+    public void createCashLogOnSettled(Application application) {
         long earn = application.getEarn();
         CashLog newCashLog =  CashLog.builder()
                 .member(application.getMember())
                 .description("지원서_" + application.getId() + "_대금_결제")
                 .eventType(EventType.정산_급여)
                 .totalAmount(earn)
-                .vat(getVat(earn))
-                .paymentFee(getPaymentFee(PayStatus.EASY_PAY,earn))
-                .netAmount(getNetAmount(PayStatus.EASY_PAY,earn))
+                .vat(paymentCalculationService.getVat(earn))
+                .paymentFee(paymentCalculationService.getPaymentFee(PayStatus.EASY_PAY,earn))
+                .netAmount(paymentCalculationService.getNetAmount(PayStatus.EASY_PAY,earn))
                 .applicationId(application.getId())
                 .build();
 
@@ -100,15 +64,16 @@ public class CashLogService {
                 .description(successDto.getOrderName())
                 .eventType(EventType.결제_토스페이먼츠)
                 .totalAmount(successDto.getTotalAmount())
-                .vat(getVat(payment.getTotalAmount()))
-                .paymentFee(getPaymentFee(payStatus, payment.getTotalAmount()))
-                .netAmount(getNetAmount(payStatus, payment.getTotalAmount()))
+                .vat(paymentCalculationService.getVat(payment.getTotalAmount()))
+                .paymentFee(paymentCalculationService.getPaymentFee(payStatus, payment.getTotalAmount()))
+                .netAmount(paymentCalculationService.getNetAmount(payStatus, payment.getTotalAmount()))
                 .applicationId(payment.getApplicationId())
                 .build();
 
         addCashLog(newCashLog);
     }
 
+    @Transactional
     public void createCashLogOnCancel(Payment payment) {
         CashLog newCashLog = CashLog.builder()
                 .member(payment.getMember())

--- a/src/main/java/com/ll/gooHaeYu/domain/payment/payment/service/PaymentCalculationService.java
+++ b/src/main/java/com/ll/gooHaeYu/domain/payment/payment/service/PaymentCalculationService.java
@@ -1,0 +1,52 @@
+package com.ll.gooHaeYu.domain.payment.payment.service;
+
+import com.ll.gooHaeYu.domain.payment.payment.entity.type.PayStatus;
+import com.ll.gooHaeYu.domain.payment.payment.entity.type.PayTypeFee;
+import com.ll.gooHaeYu.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+
+import static com.ll.gooHaeYu.global.exception.ErrorCode.NO_ENUM_CONSTANT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class PaymentCalculationService {
+
+    // 토스페이먼츠 결제 부과세 10% 반환
+    public long getVat(long totalAmount) {
+        return (int) (totalAmount * 0.1);
+    }
+
+    // 결제 수수료 반환
+    public long getPaymentFee(PayStatus payStatus, long totalAmount) {
+        PayTypeFee payTypeFee = matchPayTypeFee(payStatus);
+
+        double feePercentage = payTypeFee.getFeePercentage();
+        int transactionFee = payTypeFee.getTransactionFee();
+
+        return (int) ((totalAmount * feePercentage / 100.0) + transactionFee);
+    }
+
+    private PayTypeFee matchPayTypeFee(PayStatus payStatus) {
+        return Arrays.stream(PayTypeFee.values())
+                .filter(payTypeFee -> payTypeFee.getTypeName().equals(payStatus.getDescription()))
+                .findFirst()
+                .orElseThrow(() -> new CustomException(NO_ENUM_CONSTANT_FOUND));   // 매칭되는 PayTypeFee가 없는 경우
+    }
+
+    // 부가세와 결제 수수료의 합 반환
+    public long getTotalTaxAndFees(PayStatus payStatus, long totalAmount) {
+        return getVat(totalAmount) + getPaymentFee(payStatus, totalAmount);
+    }
+
+    // 순금액 반환
+    public long getNetAmount (PayStatus payStatus, long totalAmount) {
+        return totalAmount - getTotalTaxAndFees(payStatus, totalAmount);
+    }
+}

--- a/src/main/java/com/ll/gooHaeYu/domain/payment/payment/service/PaymentCancelService.java
+++ b/src/main/java/com/ll/gooHaeYu/domain/payment/payment/service/PaymentCancelService.java
@@ -51,7 +51,7 @@ public class PaymentCancelService {
                 new HttpEntity<>(params, headers),
                 PaymentCancelResDto.class);
 
-        cashLogService.addCashLogOnCancel(payment);
+        cashLogService.createCashLogOnCancel(payment);
 
         return paymentCancelResDto;
     }

--- a/src/main/java/com/ll/gooHaeYu/domain/payment/payment/service/PaymentService.java
+++ b/src/main/java/com/ll/gooHaeYu/domain/payment/payment/service/PaymentService.java
@@ -2,8 +2,6 @@ package com.ll.gooHaeYu.domain.payment.payment.service;
 
 import com.ll.gooHaeYu.domain.application.application.service.ApplicationService;
 import com.ll.gooHaeYu.domain.member.member.service.MemberService;
-import com.ll.gooHaeYu.domain.payment.cashLog.entity.CashLog;
-import com.ll.gooHaeYu.domain.payment.cashLog.entity.type.EventType;
 import com.ll.gooHaeYu.domain.payment.cashLog.service.CashLogService;
 import com.ll.gooHaeYu.domain.payment.payment.dto.fail.PaymentFailDto;
 import com.ll.gooHaeYu.domain.payment.payment.dto.request.PaymentReqDto;
@@ -68,7 +66,7 @@ public class PaymentService {
 
         applicationService.updateApplicationOnPaymentSuccess(payment.getApplicationId(), amount);
 
-        addCashLogOnSuccess(successDto, payment);
+        cashLogService.createCashLogOnPaid(successDto, payment);
 
         return successDto;
     }
@@ -115,24 +113,6 @@ public class PaymentService {
     private void updatePayStatusByPayment(Payment payment, String method) {
         PayStatus payStatus = PayStatus.findByMethod(method);
         payment.updatePayStatus(payStatus);
-    }
-
-    @Transactional
-    public void addCashLogOnSuccess(PaymentSuccessDto successDto, Payment payment) {
-        PayStatus payStatus = PayStatus.findByMethod(successDto.getMethod());
-
-        CashLog cashLog =  CashLog.builder()
-                .member(payment.getMember())
-                .description(successDto.getOrderName())
-                .eventType(EventType.결제_토스페이먼츠)
-                .totalAmount(successDto.getTotalAmount())
-                .vat(cashLogService.getVat(payment.getTotalAmount()))
-                .paymentFee(cashLogService.getPaymentFee(payStatus, payment.getTotalAmount()))
-                .netAmount(cashLogService.getNetAmount(payStatus, payment.getTotalAmount()))
-                .applicationId(payment.getApplicationId())
-                .build();
-
-        cashLogService.addCashLog(cashLog);
     }
 
     @Transactional

--- a/src/main/java/com/ll/gooHaeYu/domain/payment/payment/service/PaymentService.java
+++ b/src/main/java/com/ll/gooHaeYu/domain/payment/payment/service/PaymentService.java
@@ -119,6 +119,9 @@ public class PaymentService {
     public PaymentFailDto tossPaymentFail(String code, String message, String orderId) {
         handlePaymentFailure(orderId, message);
 
+        Payment payment = findPaymentByOrderId(orderId);
+        paymentRepository.delete(payment);
+
         return PaymentFailDto.builder()
                 .errorCode(code)
                 .errorMessage(message)


### PR DESCRIPTION
## 작업 내용

### 지급 방식이 개인 지급인 알바 취소 처리 구현
- 수동 알바처리 리팩토링 및 개인 지급 알바 미완료(취소) 처리 구현 
   - WorkCompletionService 리팩토링
- 개인 지급 알바 미완료(취소) 처리 프론트 구현 
   - 취소 가능 기간에는 서비스 결제일 경우, '급여 결제 취소', 개인 지급일 경우에는 '취소 요청' 버튼이 보이도록 설정



### 캐시로그 리팩토링
- 결제 시 캐시로그 생성 메서드 리팩토링 
   - PaymentService 에서 CashLogService 로 이동
- 캐시로그 서비스에서 계산 관련 메서드를 PaymentCalculationService 로 분리
- 캐시로그 서비스 리팩토링


### 그 외 리팩토링
- 실패한 결제건에 대한 Payment 객체는 지우도록 설정
- 결제 성공 페이지에서 확인 누르면 지원서 상세 페이지로 이동
<br>