### PR TITLE
Feature/s3 image upload  AWS S3 연결, 프로필 이미지 업로드 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,6 +96,9 @@ dependencies {
 	// Mail
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.apache.commons:commons-lang3:3.12.0'
+
+	// S3
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 // 테스트를 실행할때마다 jacoco 리포트 생성

--- a/front/src/lib/rq/rq.svelte.ts
+++ b/front/src/lib/rq/rq.svelte.ts
@@ -32,6 +32,7 @@ class Rq {
 		let phoneNumber = $state<string>('');
 		let email = $state<string>('');
 		let authenticated = $state<boolean>(false);
+		let profileImageUrl = $state<string>('');
 
 		return {
 			get id() {
@@ -87,6 +88,12 @@ class Rq {
 			},
 			set authenticated(value: boolean) {
 				authenticated = value;
+			},
+			get profileImageUrl() {
+				return profileImageUrl;
+			},
+			set profileImageUrl(value: string) {
+				profileImageUrl = value;
 			}
 		};
 	}
@@ -137,7 +144,9 @@ class Rq {
 		this.member.birth = '';
 		this.member.name = '';
 		this.member.phoneNumber = '';
-		(this.member.email = ''), (this.member.authenticated = false);
+		(this.member.email = ''),
+			(this.member.authenticated = false),
+			(this.member.profileImageUrl = '');
 	}
 
 	public isLogin() {

--- a/front/src/lib/types/api/v1/schema.d.ts
+++ b/front/src/lib/types/api/v1/schema.d.ts
@@ -413,6 +413,7 @@ export interface components {
       jobPostId: number;
       author: string;
       content: string;
+      authorProfileImageUrl?: string;
       /** Format: date-time */
       createAt: string;
       /** Format: date-time */

--- a/front/src/lib/types/api/v1/schema.d.ts
+++ b/front/src/lib/types/api/v1/schema.d.ts
@@ -3,755 +3,747 @@
  * Do not make direct changes to the file.
  */
 
+
 export interface paths {
-	'/api/post-comment/{postId}/comment/{commentId}': {
-		/** 댓글 수정 */
-		put: operations['modify'];
-		/** 댓글 삭제 */
-		delete: operations['delete'];
-	};
-	'/api/notification/{id}': {
-		/** 알림 읽음 처리 */
-		put: operations['read'];
-	};
-	'/api/member': {
-		/** 내 정보 조회 */
-		get: operations['detailMember'];
-		/** 내 정보 수정 */
-		put: operations['modifyMember'];
-	};
-	'/api/member/social': {
-		/** 최초 소셜로그인 - 필수 회원정보 입력 */
-		put: operations['updateSocialMember'];
-	};
-	'/api/job-posts/{id}': {
-		/** 구인공고 단건 조회 */
-		get: operations['showDetailPost'];
-		/** 구인공고 수정 */
-		put: operations['modifyPost'];
-		/** 구인공고 삭제 */
-		delete: operations['deleteJobPost'];
-	};
-	'/api/job-posts/{id}/closing': {
-		/** 조기 마감 */
-		put: operations['postEarlyClosing'];
-	};
-	'/api/chat/{roomId}': {
-		/** 채팅방 입장 */
-		get: operations['showRoom'];
-		/** 채팅방 퇴장 */
-		put: operations['exitsRoom'];
-	};
-	'/api/applications/{id}': {
-		/** 지원서 상세 내용 */
-		get: operations['detailApplication'];
-		/** 지원서 수정 */
-		put: operations['modifyApplication'];
-		/** 지원서 작성 */
-		post: operations['writeApplication'];
-		/** 지원서 삭제 */
-		delete: operations['deleteApplication'];
-	};
-	'/batch': {
-		post: operations['runBatch'];
-	};
-	'/api/post-comment/{postId}/comment': {
-		/** 댓글 작성 */
-		post: operations['write'];
-	};
-	'/api/payments': {
-		/** 결제 요청 */
-		post: operations['requestTossPayments'];
-	};
-	'/api/payments/cancel': {
-		/** 결제 취소 */
-		post: operations['tossPaymentCancel'];
-	};
-	'/api/notification/register': {
-		post: operations['register'];
-	};
-	'/api/member/review/{jobPostingId}': {
-		/** 지원자 리뷰 작성 */
-		post: operations['createReview'];
-	};
-	'/api/member/logout': {
-		/** 로그아웃 처리 및 쿠키 삭제 */
-		post: operations['logout'];
-	};
-	'/api/member/login': {
-		/** 로그인, accessToken, refreshToken 쿠키 생성됨 */
-		post: operations['login'];
-	};
-	'/api/member/join': {
-		/** 회원가입 */
-		post: operations['join'];
-	};
-	'/api/job-posts': {
-		/** 구인공고 글 목록 가져오기 */
-		get: operations['findAllPost'];
-		/** 구인공고 작성 */
-		post: operations['writePost'];
-	};
-	'/api/job-posts/{id}/interest': {
-		/** 구인공고 관심 등록 */
-		post: operations['interest'];
-		/** 구인공고 관심 제거 */
-		delete: operations['disinterest'];
-	};
-	'/api/chat/{roomId}/message': {
-		/** 채팅 메세지 로드 */
-		get: operations['writeChat_1'];
-		/** 채팅 생성 */
-		post: operations['writeChat'];
-	};
-	'/api/auth/email': {
-		/** 인증 메일 전송 */
-		post: operations['sendAuthEmail'];
-	};
-	'/api/members/verify/{code}': {
-		/** 인증코드 확인 */
-		patch: operations['verifyCode'];
-	};
-	'/api/jobs/individual/no-work/{applicationId}': {
-		/** 개인 지급 알바 미완료 처리 */
-		patch: operations['cancelIndividualNoWork'];
-	};
-	'/api/jobs/complete/{applicationId}/manually': {
-		/** 구인자가 수동으로 알바완료 처리 */
-		patch: operations['completeJobManually'];
-	};
-	'/api/employ/{postId}/{applicationIds}': {
-		/** 지원서 승인 */
-		patch: operations['approve'];
-	};
-	'/ready': {
-		/** 배포한 애플리케이션의 준비 상태를 확인 */
-		get: operations['isReady'];
-	};
-	'/member/socialLogin/{providerTypeCode}': {
-		/** 소셜 로그인 */
-		get: operations['socialLogin'];
-	};
-	'/api/post-comment/{postId}': {
-		/** 해당 공고에 달린 댓글 목록 */
-		get: operations['findByPostId'];
-	};
-	'/api/payments/{applicationId}': {
-		/** 결제정보 가져오기 */
-		get: operations['getPaymentKey'];
-	};
-	'/api/payments/success': {
-		/** 결제 성공 */
-		get: operations['tossPaymentSuccess'];
-	};
-	'/api/payments/fail': {
-		/** 결제 실패 */
-		get: operations['tossPaymentFail'];
-	};
-	'/api/notification': {
-		/** 유저 별 알림리스트 */
-		get: operations['getList'];
-	};
-	'/api/notification/new': {
-		/** 읽지 않은 알림 유무 확인 */
-		get: operations['unreadNotification'];
-	};
-	'/api/member/review': {
-		/** 나의 전체 리뷰 조회 */
-		get: operations['getAllReviews'];
-	};
-	'/api/member/review/{id}': {
-		/** 리뷰 단건 조회 */
-		get: operations['getReviewById'];
-		/** 리뷰 삭제 */
-		delete: operations['deleteReview'];
-	};
-	'/api/member/myposts': {
-		/** 내 공고 조회 */
-		get: operations['detailMyPosts'];
-	};
-	'/api/member/myinterest': {
-		/** 내 관심 공고 조회 */
-		get: operations['detailMyInterestingPosts'];
-	};
-	'/api/member/mycomments': {
-		/** 내 댓글 조회 */
-		get: operations['detailMyComments'];
-	};
-	'/api/member/myapplications': {
-		/** 내 지원서 조회 */
-		get: operations['detailMyApplications'];
-	};
-	'/api/job-posts/{id}/members/interest': {
-		/** 로그인한 유저의 해당 구인공고 관심 등록 여부 */
-		get: operations['isInterested'];
-	};
-	'/api/job-posts/sort': {
-		/** 구인공고 글 목록 정렬 */
-		get: operations['findAllPostSort'];
-	};
-	'/api/job-posts/search': {
-		/** 게시물 검색 */
-		get: operations['searchJobPostsByTitleAndBody'];
-	};
-	'/api/employ/{postId}': {
-		/** 공고 별 지원리스트 */
-		get: operations['getList_1'];
-	};
-	'/api/chat': {
-		/** 채팅방 목록 */
-		get: operations['showRoomList'];
-	};
-	'/': {
-		get: operations['showMain'];
-	};
-	'/api/notification/read': {
-		/** 읽은 알림 전부 삭제 */
-		delete: operations['deleteReadAll'];
-	};
-	'/api/notification/all': {
-		/** 알림 전부 삭제 */
-		delete: operations['deleteAll'];
-	};
+  "/api/post-comment/{postId}/comment/{commentId}": {
+    /** 댓글 수정 */
+    put: operations["modify"];
+    /** 댓글 삭제 */
+    delete: operations["delete"];
+  };
+  "/api/notification/{id}": {
+    /** 알림 읽음 처리 */
+    put: operations["read"];
+  };
+  "/api/member": {
+    /** 내 정보 조회 */
+    get: operations["detailMember"];
+    /** 내 정보 수정 */
+    put: operations["modifyMember"];
+  };
+  "/api/member/social": {
+    /** 최초 소셜로그인 - 필수 회원정보 입력 */
+    put: operations["updateSocialMember"];
+  };
+  "/api/job-posts/{id}": {
+    /** 구인공고 단건 조회 */
+    get: operations["showDetailPost"];
+    /** 구인공고 수정 */
+    put: operations["modifyPost"];
+    /** 구인공고 삭제 */
+    delete: operations["deleteJobPost"];
+  };
+  "/api/job-posts/{id}/closing": {
+    /** 조기 마감 */
+    put: operations["postEarlyClosing"];
+  };
+  "/api/chat/{roomId}": {
+    /** 채팅방 입장 */
+    get: operations["showRoom"];
+    /** 채팅방 퇴장 */
+    put: operations["exitsRoom"];
+  };
+  "/api/applications/{id}": {
+    /** 지원서 상세 내용 */
+    get: operations["detailApplication"];
+    /** 지원서 수정 */
+    put: operations["modifyApplication"];
+    /** 지원서 작성 */
+    post: operations["writeApplication"];
+    /** 지원서 삭제 */
+    delete: operations["deleteApplication"];
+  };
+  "/batch": {
+    post: operations["runBatch"];
+  };
+  "/api/post-comment/{postId}/comment": {
+    /** 댓글 작성 */
+    post: operations["write"];
+  };
+  "/api/payments": {
+    /** 결제 요청 */
+    post: operations["requestTossPayments"];
+  };
+  "/api/payments/cancel": {
+    /** 결제 취소 */
+    post: operations["tossPaymentCancel"];
+  };
+  "/api/notification/register": {
+    post: operations["register"];
+  };
+  "/api/member/review/{jobPostingId}": {
+    /** 지원자 리뷰 작성 */
+    post: operations["createReview"];
+  };
+  "/api/member/logout": {
+    /** 로그아웃 처리 및 쿠키 삭제 */
+    post: operations["logout"];
+  };
+  "/api/member/login": {
+    /** 로그인, accessToken, refreshToken 쿠키 생성됨 */
+    post: operations["login"];
+  };
+  "/api/member/join": {
+    /** 회원가입 */
+    post: operations["join"];
+  };
+  "/api/job-posts": {
+    /** 구인공고 글 목록 가져오기 */
+    get: operations["findAllPost"];
+    /** 구인공고 작성 */
+    post: operations["writePost"];
+  };
+  "/api/job-posts/{id}/interest": {
+    /** 구인공고 관심 등록 */
+    post: operations["interest"];
+    /** 구인공고 관심 제거 */
+    delete: operations["disinterest"];
+  };
+  "/api/chat/{roomId}/message": {
+    /** 채팅 메세지 로드 */
+    get: operations["writeChat_1"];
+    /** 채팅 생성 */
+    post: operations["writeChat"];
+  };
+  "/api/auth/email": {
+    /** 인증 메일 전송 */
+    post: operations["sendAuthEmail"];
+  };
+  "/api/members/verify/{code}": {
+    /** 인증코드 확인 */
+    patch: operations["verifyCode"];
+  };
+  "/api/jobs/individual/no-work/{applicationId}": {
+    /** 개인 지급 알바 미완료 처리 */
+    patch: operations["cancelIndividualNoWork"];
+  };
+  "/api/jobs/complete/{applicationId}/manually": {
+    /** 구인자가 수동으로 알바완료 처리 */
+    patch: operations["completeJobManually"];
+  };
+  "/api/employ/{postId}/{applicationIds}": {
+    /** 지원서 승인 */
+    patch: operations["approve"];
+  };
+  "/ready": {
+    /** 배포한 애플리케이션의 준비 상태를 확인 */
+    get: operations["isReady"];
+  };
+  "/member/socialLogin/{providerTypeCode}": {
+    /** 소셜 로그인 */
+    get: operations["socialLogin"];
+  };
+  "/api/post-comment/{postId}": {
+    /** 해당 공고에 달린 댓글 목록 */
+    get: operations["findByPostId"];
+  };
+  "/api/payments/{applicationId}": {
+    /** 결제정보 가져오기 */
+    get: operations["getPaymentKey"];
+  };
+  "/api/payments/success": {
+    /** 결제 성공 */
+    get: operations["tossPaymentSuccess"];
+  };
+  "/api/payments/fail": {
+    /** 결제 실패 */
+    get: operations["tossPaymentFail"];
+  };
+  "/api/notification": {
+    /** 유저 별 알림리스트 */
+    get: operations["getList"];
+  };
+  "/api/notification/new": {
+    /** 읽지 않은 알림 유무 확인 */
+    get: operations["unreadNotification"];
+  };
+  "/api/member/review": {
+    /** 나의 전체 리뷰 조회 */
+    get: operations["getAllReviews"];
+  };
+  "/api/member/review/{id}": {
+    /** 리뷰 단건 조회 */
+    get: operations["getReviewById"];
+    /** 리뷰 삭제 */
+    delete: operations["deleteReview"];
+  };
+  "/api/member/myposts": {
+    /** 내 공고 조회 */
+    get: operations["detailMyPosts"];
+  };
+  "/api/member/myinterest": {
+    /** 내 관심 공고 조회 */
+    get: operations["detailMyInterestingPosts"];
+  };
+  "/api/member/mycomments": {
+    /** 내 댓글 조회 */
+    get: operations["detailMyComments"];
+  };
+  "/api/member/myapplications": {
+    /** 내 지원서 조회 */
+    get: operations["detailMyApplications"];
+  };
+  "/api/job-posts/{id}/members/interest": {
+    /** 로그인한 유저의 해당 구인공고 관심 등록 여부 */
+    get: operations["isInterested"];
+  };
+  "/api/job-posts/sort": {
+    /** 구인공고 글 목록 정렬 */
+    get: operations["findAllPostSort"];
+  };
+  "/api/job-posts/search": {
+    /** 게시물 검색 */
+    get: operations["searchJobPostsByTitleAndBody"];
+  };
+  "/api/employ/{postId}": {
+    /** 공고 별 지원리스트 */
+    get: operations["getList_1"];
+  };
+  "/api/chat": {
+    /** 채팅방 목록 */
+    get: operations["showRoomList"];
+  };
+  "/": {
+    get: operations["showMain"];
+  };
+  "/api/notification/read": {
+    /** 읽은 알림 전부 삭제 */
+    delete: operations["deleteReadAll"];
+  };
+  "/api/notification/all": {
+    /** 알림 전부 삭제 */
+    delete: operations["deleteAll"];
+  };
 }
 
 export type webhooks = Record<string, never>;
 
 export interface components {
-	schemas: {
-		Register: {
-			content: string;
-		};
-		Modify: {
-			/** @enum {string} */
-			gender?: 'MALE' | 'FEMALE' | 'UNDEFINED';
-			location?: string;
-			/** Format: date */
-			birth?: string;
-			password?: string;
-		};
-		ApiResponseEmpty: {
-			/** Format: int32 */
-			statusCode?: number;
-			message: string;
-			/** @enum {string} */
-			resultType: 'SUCCESS' | 'VALIDATION_EXCEPTION' | 'CUSTOM_EXCEPTION';
-			errorCode?: string;
-			data: components['schemas']['Empty'];
-		};
-		Empty: Record<string, never>;
-		SocialProfileForm: {
-			name: string;
-			phoneNumber: string;
-			/** @enum {string} */
-			gender?: 'MALE' | 'FEMALE' | 'UNDEFINED';
-			location: string;
-			/** Format: date */
-			birth: string;
-		};
-		ApiResponseMemberDto: {
-			/** Format: int32 */
-			statusCode?: number;
-			message: string;
-			/** @enum {string} */
-			resultType: 'SUCCESS' | 'VALIDATION_EXCEPTION' | 'CUSTOM_EXCEPTION';
-			errorCode?: string;
-			data: components['schemas']['MemberDto'];
-		};
-		MemberDto: {
-			/** Format: int64 */
-			id: number;
-			username: string;
-			/** @enum {string} */
-			gender?: 'MALE' | 'FEMALE' | 'UNDEFINED';
-			location: string;
-			/** Format: date */
-			birth?: string;
-			name: string;
-			phoneNumber: string;
-			email: string;
-			authenticated?: boolean;
-		};
-		ApiResponseModify: {
-			/** Format: int32 */
-			statusCode?: number;
-			message: string;
-			/** @enum {string} */
-			resultType: 'SUCCESS' | 'VALIDATION_EXCEPTION' | 'CUSTOM_EXCEPTION';
-			errorCode?: string;
-			data: components['schemas']['Modify'];
-		};
-		ApiResponseRegister: {
-			/** Format: int32 */
-			statusCode?: number;
-			message: string;
-			/** @enum {string} */
-			resultType: 'SUCCESS' | 'VALIDATION_EXCEPTION' | 'CUSTOM_EXCEPTION';
-			errorCode?: string;
-			data: components['schemas']['Register'];
-		};
-		PaymentReqDto: {
-			/** @enum {string} */
-			payStatus: 'REQUEST' | 'CARD' | 'EASY_PAY';
-			/** Format: int64 */
-			amount: number;
-			orderId?: string;
-			orderName?: string;
-			/** Format: int64 */
-			applicationId?: number;
-		};
-		ApiResponsePaymentResDto: {
-			/** Format: int32 */
-			statusCode?: number;
-			message: string;
-			/** @enum {string} */
-			resultType: 'SUCCESS' | 'VALIDATION_EXCEPTION' | 'CUSTOM_EXCEPTION';
-			errorCode?: string;
-			data: components['schemas']['PaymentResDto'];
-		};
-		PaymentResDto: {
-			/** @enum {string} */
-			payStatus: 'REQUEST' | 'CARD' | 'EASY_PAY';
-			/** Format: int64 */
-			amount: number;
-			orderId: string;
-			orderName: string;
-			payer: string;
-			successUrl?: string;
-			failUrl?: string;
-			failReason?: string;
-			canceled?: boolean;
-			cancelReason?: string;
-		};
-		ApiResponsePaymentCancelResDto: {
-			/** Format: int32 */
-			statusCode?: number;
-			message: string;
-			/** @enum {string} */
-			resultType: 'SUCCESS' | 'VALIDATION_EXCEPTION' | 'CUSTOM_EXCEPTION';
-			errorCode?: string;
-			data: components['schemas']['PaymentCancelResDto'];
-		};
-		PaymentCancelResDto: {
-			/** Format: int32 */
-			cancelAmount?: number;
-			transactionKey?: string;
-			canceledAt?: string;
-		};
-		ApplicantReviewDto: {
-			/** Format: int64 */
-			id?: number;
-			body?: string;
-			/** Format: double */
-			score?: number;
-			/** Format: int64 */
-			jobPostingId?: number;
-			/** Format: int64 */
-			applicantId?: number;
-		};
-		ApiResponseApplicantReviewDto: {
-			/** Format: int32 */
-			statusCode?: number;
-			message: string;
-			/** @enum {string} */
-			resultType: 'SUCCESS' | 'VALIDATION_EXCEPTION' | 'CUSTOM_EXCEPTION';
-			errorCode?: string;
-			data: components['schemas']['ApplicantReviewDto'];
-		};
-		LoginForm: {
-			username: string;
-			password: string;
-		};
-		JoinForm: {
-			username: string;
-			password: string;
-			name: string;
-			phoneNumber: string;
-			email: string;
-			/** @enum {string} */
-			gender?: 'MALE' | 'FEMALE' | 'UNDEFINED';
-			location: string;
-			/** Format: date */
-			birth: string;
-		};
-		ApiResponseJoinForm: {
-			/** Format: int32 */
-			statusCode?: number;
-			message: string;
-			/** @enum {string} */
-			resultType: 'SUCCESS' | 'VALIDATION_EXCEPTION' | 'CUSTOM_EXCEPTION';
-			errorCode?: string;
-			data: components['schemas']['JoinForm'];
-		};
-		ApiResponseListCommentDto: {
-			/** Format: int32 */
-			statusCode?: number;
-			message: string;
-			/** @enum {string} */
-			resultType: 'SUCCESS' | 'VALIDATION_EXCEPTION' | 'CUSTOM_EXCEPTION';
-			errorCode?: string;
-			data: components['schemas']['CommentDto'][];
-		};
-		CommentDto: {
-			/** Format: int64 */
-			id: number;
-			/** Format: int64 */
-			jobPostId: number;
-			author: string;
-			content: string;
-			/** Format: date-time */
-			createAt: string;
-			/** Format: date-time */
-			modifyAt: string;
-		};
-		ApiResponsePaymentDto: {
-			/** Format: int32 */
-			statusCode?: number;
-			message: string;
-			/** @enum {string} */
-			resultType: 'SUCCESS' | 'VALIDATION_EXCEPTION' | 'CUSTOM_EXCEPTION';
-			errorCode?: string;
-			data: components['schemas']['PaymentDto'];
-		};
-		PaymentDto: {
-			paymentKey?: string;
-			/** Format: int64 */
-			totalAmount?: number;
-			orderName?: string;
-			paid?: boolean;
-			canceled?: boolean;
-			/** Format: int64 */
-			applicationId?: number;
-			payStatus?: string;
-		};
-		ApiResponsePaymentSuccessDto: {
-			/** Format: int32 */
-			statusCode?: number;
-			message: string;
-			/** @enum {string} */
-			resultType: 'SUCCESS' | 'VALIDATION_EXCEPTION' | 'CUSTOM_EXCEPTION';
-			errorCode?: string;
-			data: components['schemas']['PaymentSuccessDto'];
-		};
-		PaymentSuccessDto: {
-			paymentKey?: string;
-			orderId?: string;
-			/** Format: int64 */
-			applicationId?: number;
-			orderName?: string;
-			method?: string;
-			/** Format: int32 */
-			totalAmount?: number;
-			approvedAt?: string;
-			card?: components['schemas']['SuccessCardDto'];
-			easyPay?: components['schemas']['SuccessEasyPayDto'];
-		};
-		SuccessCardDto: {
-			company?: string;
-			number?: string;
-			installmentPlanMonths?: string;
-			isInterestFree?: string;
-			approveNo?: string;
-			useCardPoint?: string;
-			cardType?: string;
-			acquireStatus?: string;
-		};
-		SuccessEasyPayDto: {
-			provider?: string;
-			/** Format: int32 */
-			amount?: number;
-			/** Format: int32 */
-			discountAmount?: number;
-		};
-		ApiResponsePaymentFailDto: {
-			/** Format: int32 */
-			statusCode?: number;
-			message: string;
-			/** @enum {string} */
-			resultType: 'SUCCESS' | 'VALIDATION_EXCEPTION' | 'CUSTOM_EXCEPTION';
-			errorCode?: string;
-			data: components['schemas']['PaymentFailDto'];
-		};
-		PaymentFailDto: {
-			errorCode?: string;
-			errorMessage?: string;
-			orderId?: string;
-		};
-		ApiResponseListNotificationDto: {
-			/** Format: int32 */
-			statusCode?: number;
-			message: string;
-			/** @enum {string} */
-			resultType: 'SUCCESS' | 'VALIDATION_EXCEPTION' | 'CUSTOM_EXCEPTION';
-			errorCode?: string;
-			data: components['schemas']['NotificationDto'][];
-		};
-		NotificationDto: {
-			/** Format: int64 */
-			id?: number;
-			createAt?: string;
-			toMember?: string;
-			fromMember?: string;
-			relPostTitle?: string;
-			/** @enum {string} */
-			causeTypeCode?:
-				| 'POST_MODIFICATION'
-				| 'POST_DELETED'
-				| 'POST_INTERESTED'
-				| 'POST_DEADLINE'
-				| 'COMMENT_CREATED'
-				| 'APPLICATION_CREATED'
-				| 'APPLICATION_MODIFICATION'
-				| 'APPLICATION_APPROVED'
-				| 'APPLICATION_UNAPPROVE'
-				| 'CHATROOM_CREATED'
-				| 'CALCULATE_PAYMENT';
-			/** @enum {string} */
-			resultTypeCode?: 'NOTICE' | 'DELETE' | 'APPROVE';
-			seen?: boolean;
-			url?: string;
-		};
-		ApiResponseBoolean: {
-			/** Format: int32 */
-			statusCode?: number;
-			message: string;
-			/** @enum {string} */
-			resultType: 'SUCCESS' | 'VALIDATION_EXCEPTION' | 'CUSTOM_EXCEPTION';
-			errorCode?: string;
-			data: boolean;
-		};
-		ApiResponseListApplicantReviewDto: {
-			/** Format: int32 */
-			statusCode?: number;
-			message: string;
-			/** @enum {string} */
-			resultType: 'SUCCESS' | 'VALIDATION_EXCEPTION' | 'CUSTOM_EXCEPTION';
-			errorCode?: string;
-			data: components['schemas']['ApplicantReviewDto'][];
-		};
-		ApiResponseListJobPostDto: {
-			/** Format: int32 */
-			statusCode?: number;
-			message: string;
-			/** @enum {string} */
-			resultType: 'SUCCESS' | 'VALIDATION_EXCEPTION' | 'CUSTOM_EXCEPTION';
-			errorCode?: string;
-			data: components['schemas']['JobPostDto'][];
-		};
-		JobPostDto: {
-			/** Format: int64 */
-			id: number;
-			author: string;
-			title: string;
-			location: string;
-			/** Format: int64 */
-			commentsCount: number;
-			/** Format: int64 */
-			incrementViewCount: number;
-			/** Format: int64 */
-			interestsCount: number;
-			createdAt: string;
-			employed: boolean;
-			/** Format: date */
-			deadLine?: string;
-			/** Format: date */
-			jobStartDate?: string;
-			closed?: boolean;
-		};
-		ApiResponseListApplicationDto: {
-			/** Format: int32 */
-			statusCode?: number;
-			message: string;
-			/** @enum {string} */
-			resultType: 'SUCCESS' | 'VALIDATION_EXCEPTION' | 'CUSTOM_EXCEPTION';
-			errorCode?: string;
-			data: components['schemas']['ApplicationDto'][];
-		};
-		ApplicationDto: {
-			/** Format: int64 */
-			id: number;
-			jobPostAuthorUsername: string;
-			/** Format: int64 */
-			jobPostId: number;
-			jobPostName: string;
-			author: string;
-			body: string;
-			name: string;
-			/** Format: date */
-			birth: string;
-			phone: string;
-			location: string;
-			wageStatus: string;
-			wagePaymentMethod: string;
-			/** Format: int32 */
-			wages: number;
-			/** Format: date-time */
-			createdAt?: string;
-			approve?: boolean;
-		};
-		ApiResponseJobPostDetailDto: {
-			/** Format: int32 */
-			statusCode?: number;
-			message: string;
-			/** @enum {string} */
-			resultType: 'SUCCESS' | 'VALIDATION_EXCEPTION' | 'CUSTOM_EXCEPTION';
-			errorCode?: string;
-			data: components['schemas']['JobPostDetailDto'];
-		};
-		JobPostDetailDto: {
-			/** Format: int64 */
-			id: number;
-			author: string;
-			title: string;
-			location: string;
-			/** Format: int64 */
-			commentsCount: number;
-			/** Format: int64 */
-			incrementViewCount: number;
-			/** Format: int64 */
-			interestsCount: number;
-			createdAt: string;
-			employed: boolean;
-			/** Format: date */
-			deadLine?: string;
-			/** Format: date */
-			jobStartDate?: string;
-			body: string;
-			/** Format: int64 */
-			applicationCount?: number;
-			/** Format: int32 */
-			minAge?: number;
-			/** @enum {string} */
-			gender?: 'MALE' | 'FEMALE' | 'UNDEFINED';
-			modifiedAt?: string;
-			interestedUsernames?: string[];
-			/** Format: int32 */
-			workTime?: number;
-			/** Format: int32 */
-			workDays?: number;
-			/** Format: int32 */
-			cost?: number;
-			/** @enum {string} */
-			payBasis?: 'UNDEFINED' | 'TOTAL_HOURS' | 'TOTAL_DAYS';
-			/** @enum {string} */
-			wagePaymentMethod?: 'UNDEFINED' | 'INDIVIDUAL_PAYMENT' | 'SERVICE_PAYMENT';
-			closed?: boolean;
-		};
-		ApiResponseGetPostsResponseBody: {
-			/** Format: int32 */
-			statusCode?: number;
-			message: string;
-			/** @enum {string} */
-			resultType: 'SUCCESS' | 'VALIDATION_EXCEPTION' | 'CUSTOM_EXCEPTION';
-			errorCode?: string;
-			data: components['schemas']['GetPostsResponseBody'];
-		};
-		GetPostsResponseBody: {
-			itemPage: components['schemas']['PageDtoJobPostDto'];
-		};
-		PageDtoJobPostDto: {
-			/** Format: int64 */
-			totalElementsCount: number;
-			/** Format: int64 */
-			pageElementsCount: number;
-			/** Format: int64 */
-			totalPagesCount: number;
-			/** Format: int32 */
-			number: number;
-			content: components['schemas']['JobPostDto'][];
-		};
-		ApiResponseListRoomListDto: {
-			/** Format: int32 */
-			statusCode?: number;
-			message: string;
-			/** @enum {string} */
-			resultType: 'SUCCESS' | 'VALIDATION_EXCEPTION' | 'CUSTOM_EXCEPTION';
-			errorCode?: string;
-			data: components['schemas']['RoomListDto'][];
-		};
-		RoomListDto: {
-			/** Format: int64 */
-			roomId?: number;
-			username1?: string;
-			username2?: string;
-			lastChat?: string;
-			lastChatDate?: string;
-		};
-		ApiResponseRoomDto: {
-			/** Format: int32 */
-			statusCode?: number;
-			message: string;
-			/** @enum {string} */
-			resultType: 'SUCCESS' | 'VALIDATION_EXCEPTION' | 'CUSTOM_EXCEPTION';
-			errorCode?: string;
-			data: components['schemas']['RoomDto'];
-		};
-		Message: {
-			/** Format: int64 */
-			id?: number;
-			room?: components['schemas']['Room'];
-			sender?: string;
-			content?: string;
-			/** Format: date-time */
-			createdAt?: string;
-		};
-		Room: {
-			/** Format: int64 */
-			id?: number;
-			username1?: string;
-			username2?: string;
-			/** Format: date-time */
-			user1Enter?: string;
-			/** Format: date-time */
-			user2Enter?: string;
-			user1HasExit?: boolean;
-			user2HasExit?: boolean;
-		};
-		RoomDto: {
-			username1?: string;
-			username2?: string;
-			messages?: components['schemas']['Message'][];
-		};
-		ApiResponseListMessageDto: {
-			/** Format: int32 */
-			statusCode?: number;
-			message: string;
-			/** @enum {string} */
-			resultType: 'SUCCESS' | 'VALIDATION_EXCEPTION' | 'CUSTOM_EXCEPTION';
-			errorCode?: string;
-			data: components['schemas']['MessageDto'][];
-		};
-		MessageDto: {
-			/** Format: int64 */
-			id?: number;
-			sender: string;
-			text: string;
-			createdAt?: string;
-		};
-		ApiResponseApplicationDto: {
-			/** Format: int32 */
-			statusCode?: number;
-			message: string;
-			/** @enum {string} */
-			resultType: 'SUCCESS' | 'VALIDATION_EXCEPTION' | 'CUSTOM_EXCEPTION';
-			errorCode?: string;
-			data: components['schemas']['ApplicationDto'];
-		};
-		ApiResponseString: {
-			/** Format: int32 */
-			statusCode?: number;
-			message: string;
-			/** @enum {string} */
-			resultType: 'SUCCESS' | 'VALIDATION_EXCEPTION' | 'CUSTOM_EXCEPTION';
-			errorCode?: string;
-			data: string;
-		};
-	};
-	responses: never;
-	parameters: never;
-	requestBodies: never;
-	headers: never;
-	pathItems: never;
+  schemas: {
+    Register: {
+      content: string;
+    };
+    Modify: {
+      /** @enum {string} */
+      gender?: "MALE" | "FEMALE" | "UNDEFINED";
+      location?: string;
+      /** Format: date */
+      birth?: string;
+      password?: string;
+    };
+    ApiResponseEmpty: {
+      /** Format: int32 */
+      statusCode?: number;
+      message: string;
+      /** @enum {string} */
+      resultType: "SUCCESS" | "VALIDATION_EXCEPTION" | "CUSTOM_EXCEPTION";
+      errorCode?: string;
+      data: components["schemas"]["Empty"];
+    };
+    Empty: Record<string, never>;
+    SocialProfileForm: {
+      name: string;
+      phoneNumber: string;
+      /** @enum {string} */
+      gender?: "MALE" | "FEMALE" | "UNDEFINED";
+      location: string;
+      /** Format: date */
+      birth: string;
+      /** Format: binary */
+      image?: string;
+    };
+    ApiResponseMemberDto: {
+      /** Format: int32 */
+      statusCode?: number;
+      message: string;
+      /** @enum {string} */
+      resultType: "SUCCESS" | "VALIDATION_EXCEPTION" | "CUSTOM_EXCEPTION";
+      errorCode?: string;
+      data: components["schemas"]["MemberDto"];
+    };
+    MemberDto: {
+      /** Format: int64 */
+      id: number;
+      username: string;
+      /** @enum {string} */
+      gender?: "MALE" | "FEMALE" | "UNDEFINED";
+      location: string;
+      /** Format: date */
+      birth?: string;
+      name: string;
+      phoneNumber: string;
+      email: string;
+      authenticated?: boolean;
+    };
+    ApiResponseModify: {
+      /** Format: int32 */
+      statusCode?: number;
+      message: string;
+      /** @enum {string} */
+      resultType: "SUCCESS" | "VALIDATION_EXCEPTION" | "CUSTOM_EXCEPTION";
+      errorCode?: string;
+      data: components["schemas"]["Modify"];
+    };
+    ApiResponseRegister: {
+      /** Format: int32 */
+      statusCode?: number;
+      message: string;
+      /** @enum {string} */
+      resultType: "SUCCESS" | "VALIDATION_EXCEPTION" | "CUSTOM_EXCEPTION";
+      errorCode?: string;
+      data: components["schemas"]["Register"];
+    };
+    PaymentReqDto: {
+      /** @enum {string} */
+      payStatus: "REQUEST" | "CARD" | "EASY_PAY";
+      /** Format: int64 */
+      amount: number;
+      orderId?: string;
+      orderName?: string;
+      /** Format: int64 */
+      applicationId?: number;
+    };
+    ApiResponsePaymentResDto: {
+      /** Format: int32 */
+      statusCode?: number;
+      message: string;
+      /** @enum {string} */
+      resultType: "SUCCESS" | "VALIDATION_EXCEPTION" | "CUSTOM_EXCEPTION";
+      errorCode?: string;
+      data: components["schemas"]["PaymentResDto"];
+    };
+    PaymentResDto: {
+      /** @enum {string} */
+      payStatus: "REQUEST" | "CARD" | "EASY_PAY";
+      /** Format: int64 */
+      amount: number;
+      orderId: string;
+      orderName: string;
+      payer: string;
+      successUrl?: string;
+      failUrl?: string;
+      failReason?: string;
+      canceled?: boolean;
+      cancelReason?: string;
+    };
+    ApiResponsePaymentCancelResDto: {
+      /** Format: int32 */
+      statusCode?: number;
+      message: string;
+      /** @enum {string} */
+      resultType: "SUCCESS" | "VALIDATION_EXCEPTION" | "CUSTOM_EXCEPTION";
+      errorCode?: string;
+      data: components["schemas"]["PaymentCancelResDto"];
+    };
+    PaymentCancelResDto: {
+      /** Format: int32 */
+      cancelAmount?: number;
+      transactionKey?: string;
+      canceledAt?: string;
+    };
+    ApplicantReviewDto: {
+      /** Format: int64 */
+      id?: number;
+      body?: string;
+      /** Format: double */
+      score?: number;
+      /** Format: int64 */
+      jobPostingId?: number;
+      /** Format: int64 */
+      applicantId?: number;
+    };
+    ApiResponseApplicantReviewDto: {
+      /** Format: int32 */
+      statusCode?: number;
+      message: string;
+      /** @enum {string} */
+      resultType: "SUCCESS" | "VALIDATION_EXCEPTION" | "CUSTOM_EXCEPTION";
+      errorCode?: string;
+      data: components["schemas"]["ApplicantReviewDto"];
+    };
+    LoginForm: {
+      username: string;
+      password: string;
+    };
+    JoinForm: {
+      username: string;
+      password: string;
+      name: string;
+      phoneNumber: string;
+      email: string;
+      /** @enum {string} */
+      gender?: "MALE" | "FEMALE" | "UNDEFINED";
+      location: string;
+      /** Format: date */
+      birth: string;
+    };
+    ApiResponseJoinForm: {
+      /** Format: int32 */
+      statusCode?: number;
+      message: string;
+      /** @enum {string} */
+      resultType: "SUCCESS" | "VALIDATION_EXCEPTION" | "CUSTOM_EXCEPTION";
+      errorCode?: string;
+      data: components["schemas"]["JoinForm"];
+    };
+    ApiResponseListCommentDto: {
+      /** Format: int32 */
+      statusCode?: number;
+      message: string;
+      /** @enum {string} */
+      resultType: "SUCCESS" | "VALIDATION_EXCEPTION" | "CUSTOM_EXCEPTION";
+      errorCode?: string;
+      data: components["schemas"]["CommentDto"][];
+    };
+    CommentDto: {
+      /** Format: int64 */
+      id: number;
+      /** Format: int64 */
+      jobPostId: number;
+      author: string;
+      content: string;
+      /** Format: date-time */
+      createAt: string;
+      /** Format: date-time */
+      modifyAt: string;
+    };
+    ApiResponsePaymentDto: {
+      /** Format: int32 */
+      statusCode?: number;
+      message: string;
+      /** @enum {string} */
+      resultType: "SUCCESS" | "VALIDATION_EXCEPTION" | "CUSTOM_EXCEPTION";
+      errorCode?: string;
+      data: components["schemas"]["PaymentDto"];
+    };
+    PaymentDto: {
+      paymentKey?: string;
+      /** Format: int64 */
+      totalAmount?: number;
+      orderName?: string;
+      paid?: boolean;
+      canceled?: boolean;
+      /** Format: int64 */
+      applicationId?: number;
+      payStatus?: string;
+    };
+    ApiResponsePaymentSuccessDto: {
+      /** Format: int32 */
+      statusCode?: number;
+      message: string;
+      /** @enum {string} */
+      resultType: "SUCCESS" | "VALIDATION_EXCEPTION" | "CUSTOM_EXCEPTION";
+      errorCode?: string;
+      data: components["schemas"]["PaymentSuccessDto"];
+    };
+    PaymentSuccessDto: {
+      paymentKey?: string;
+      orderId?: string;
+      /** Format: int64 */
+      applicationId?: number;
+      orderName?: string;
+      method?: string;
+      /** Format: int32 */
+      totalAmount?: number;
+      approvedAt?: string;
+      card?: components["schemas"]["SuccessCardDto"];
+      easyPay?: components["schemas"]["SuccessEasyPayDto"];
+    };
+    SuccessCardDto: {
+      company?: string;
+      number?: string;
+      installmentPlanMonths?: string;
+      isInterestFree?: string;
+      approveNo?: string;
+      useCardPoint?: string;
+      cardType?: string;
+      acquireStatus?: string;
+    };
+    SuccessEasyPayDto: {
+      provider?: string;
+      /** Format: int32 */
+      amount?: number;
+      /** Format: int32 */
+      discountAmount?: number;
+    };
+    ApiResponsePaymentFailDto: {
+      /** Format: int32 */
+      statusCode?: number;
+      message: string;
+      /** @enum {string} */
+      resultType: "SUCCESS" | "VALIDATION_EXCEPTION" | "CUSTOM_EXCEPTION";
+      errorCode?: string;
+      data: components["schemas"]["PaymentFailDto"];
+    };
+    PaymentFailDto: {
+      errorCode?: string;
+      errorMessage?: string;
+      orderId?: string;
+    };
+    ApiResponseListNotificationDto: {
+      /** Format: int32 */
+      statusCode?: number;
+      message: string;
+      /** @enum {string} */
+      resultType: "SUCCESS" | "VALIDATION_EXCEPTION" | "CUSTOM_EXCEPTION";
+      errorCode?: string;
+      data: components["schemas"]["NotificationDto"][];
+    };
+    NotificationDto: {
+      /** Format: int64 */
+      id?: number;
+      createAt?: string;
+      toMember?: string;
+      fromMember?: string;
+      relPostTitle?: string;
+      /** @enum {string} */
+      causeTypeCode?: "POST_MODIFICATION" | "POST_DELETED" | "POST_INTERESTED" | "POST_DEADLINE" | "COMMENT_CREATED" | "APPLICATION_CREATED" | "APPLICATION_MODIFICATION" | "APPLICATION_APPROVED" | "APPLICATION_UNAPPROVE" | "CHATROOM_CREATED" | "CALCULATE_PAYMENT";
+      /** @enum {string} */
+      resultTypeCode?: "NOTICE" | "DELETE" | "APPROVE";
+      seen?: boolean;
+      url?: string;
+    };
+    ApiResponseBoolean: {
+      /** Format: int32 */
+      statusCode?: number;
+      message: string;
+      /** @enum {string} */
+      resultType: "SUCCESS" | "VALIDATION_EXCEPTION" | "CUSTOM_EXCEPTION";
+      errorCode?: string;
+      data: boolean;
+    };
+    ApiResponseListApplicantReviewDto: {
+      /** Format: int32 */
+      statusCode?: number;
+      message: string;
+      /** @enum {string} */
+      resultType: "SUCCESS" | "VALIDATION_EXCEPTION" | "CUSTOM_EXCEPTION";
+      errorCode?: string;
+      data: components["schemas"]["ApplicantReviewDto"][];
+    };
+    ApiResponseListJobPostDto: {
+      /** Format: int32 */
+      statusCode?: number;
+      message: string;
+      /** @enum {string} */
+      resultType: "SUCCESS" | "VALIDATION_EXCEPTION" | "CUSTOM_EXCEPTION";
+      errorCode?: string;
+      data: components["schemas"]["JobPostDto"][];
+    };
+    JobPostDto: {
+      /** Format: int64 */
+      id: number;
+      author: string;
+      title: string;
+      location: string;
+      /** Format: int64 */
+      commentsCount: number;
+      /** Format: int64 */
+      incrementViewCount: number;
+      /** Format: int64 */
+      interestsCount: number;
+      createdAt: string;
+      employed: boolean;
+      /** Format: date */
+      deadLine?: string;
+      /** Format: date */
+      jobStartDate?: string;
+      closed?: boolean;
+    };
+    ApiResponseListApplicationDto: {
+      /** Format: int32 */
+      statusCode?: number;
+      message: string;
+      /** @enum {string} */
+      resultType: "SUCCESS" | "VALIDATION_EXCEPTION" | "CUSTOM_EXCEPTION";
+      errorCode?: string;
+      data: components["schemas"]["ApplicationDto"][];
+    };
+    ApplicationDto: {
+      /** Format: int64 */
+      id: number;
+      jobPostAuthorUsername: string;
+      /** Format: int64 */
+      jobPostId: number;
+      jobPostName: string;
+      author: string;
+      body: string;
+      name: string;
+      /** Format: date */
+      birth: string;
+      phone: string;
+      location: string;
+      wageStatus: string;
+      wagePaymentMethod: string;
+      /** Format: int32 */
+      wages: number;
+      /** Format: date-time */
+      createdAt?: string;
+      approve?: boolean;
+    };
+    ApiResponseJobPostDetailDto: {
+      /** Format: int32 */
+      statusCode?: number;
+      message: string;
+      /** @enum {string} */
+      resultType: "SUCCESS" | "VALIDATION_EXCEPTION" | "CUSTOM_EXCEPTION";
+      errorCode?: string;
+      data: components["schemas"]["JobPostDetailDto"];
+    };
+    JobPostDetailDto: {
+      /** Format: int64 */
+      id: number;
+      author: string;
+      title: string;
+      location: string;
+      /** Format: int64 */
+      commentsCount: number;
+      /** Format: int64 */
+      incrementViewCount: number;
+      /** Format: int64 */
+      interestsCount: number;
+      createdAt: string;
+      employed: boolean;
+      /** Format: date */
+      deadLine?: string;
+      /** Format: date */
+      jobStartDate?: string;
+      body: string;
+      /** Format: int64 */
+      applicationCount?: number;
+      /** Format: int32 */
+      minAge?: number;
+      /** @enum {string} */
+      gender?: "MALE" | "FEMALE" | "UNDEFINED";
+      modifiedAt?: string;
+      interestedUsernames?: string[];
+      /** Format: int32 */
+      workTime?: number;
+      /** Format: int32 */
+      workDays?: number;
+      /** Format: int32 */
+      cost?: number;
+      /** @enum {string} */
+      payBasis?: "UNDEFINED" | "TOTAL_HOURS" | "TOTAL_DAYS";
+      /** @enum {string} */
+      wagePaymentMethod?: "UNDEFINED" | "INDIVIDUAL_PAYMENT" | "SERVICE_PAYMENT";
+      closed?: boolean;
+    };
+    ApiResponseGetPostsResponseBody: {
+      /** Format: int32 */
+      statusCode?: number;
+      message: string;
+      /** @enum {string} */
+      resultType: "SUCCESS" | "VALIDATION_EXCEPTION" | "CUSTOM_EXCEPTION";
+      errorCode?: string;
+      data: components["schemas"]["GetPostsResponseBody"];
+    };
+    GetPostsResponseBody: {
+      itemPage: components["schemas"]["PageDtoJobPostDto"];
+    };
+    PageDtoJobPostDto: {
+      /** Format: int64 */
+      totalElementsCount: number;
+      /** Format: int64 */
+      pageElementsCount: number;
+      /** Format: int64 */
+      totalPagesCount: number;
+      /** Format: int32 */
+      number: number;
+      content: components["schemas"]["JobPostDto"][];
+    };
+    ApiResponseListRoomListDto: {
+      /** Format: int32 */
+      statusCode?: number;
+      message: string;
+      /** @enum {string} */
+      resultType: "SUCCESS" | "VALIDATION_EXCEPTION" | "CUSTOM_EXCEPTION";
+      errorCode?: string;
+      data: components["schemas"]["RoomListDto"][];
+    };
+    RoomListDto: {
+      /** Format: int64 */
+      roomId?: number;
+      username1?: string;
+      username2?: string;
+      lastChat?: string;
+      lastChatDate?: string;
+    };
+    ApiResponseRoomDto: {
+      /** Format: int32 */
+      statusCode?: number;
+      message: string;
+      /** @enum {string} */
+      resultType: "SUCCESS" | "VALIDATION_EXCEPTION" | "CUSTOM_EXCEPTION";
+      errorCode?: string;
+      data: components["schemas"]["RoomDto"];
+    };
+    Message: {
+      /** Format: int64 */
+      id?: number;
+      room?: components["schemas"]["Room"];
+      sender?: string;
+      content?: string;
+      /** Format: date-time */
+      createdAt?: string;
+    };
+    Room: {
+      /** Format: int64 */
+      id?: number;
+      username1?: string;
+      username2?: string;
+      /** Format: date-time */
+      user1Enter?: string;
+      /** Format: date-time */
+      user2Enter?: string;
+      user1HasExit?: boolean;
+      user2HasExit?: boolean;
+    };
+    RoomDto: {
+      username1?: string;
+      username2?: string;
+      messages?: components["schemas"]["Message"][];
+    };
+    ApiResponseListMessageDto: {
+      /** Format: int32 */
+      statusCode?: number;
+      message: string;
+      /** @enum {string} */
+      resultType: "SUCCESS" | "VALIDATION_EXCEPTION" | "CUSTOM_EXCEPTION";
+      errorCode?: string;
+      data: components["schemas"]["MessageDto"][];
+    };
+    MessageDto: {
+      /** Format: int64 */
+      id?: number;
+      sender: string;
+      text: string;
+      createdAt?: string;
+    };
+    ApiResponseApplicationDto: {
+      /** Format: int32 */
+      statusCode?: number;
+      message: string;
+      /** @enum {string} */
+      resultType: "SUCCESS" | "VALIDATION_EXCEPTION" | "CUSTOM_EXCEPTION";
+      errorCode?: string;
+      data: components["schemas"]["ApplicationDto"];
+    };
+    ApiResponseString: {
+      /** Format: int32 */
+      statusCode?: number;
+      message: string;
+      /** @enum {string} */
+      resultType: "SUCCESS" | "VALIDATION_EXCEPTION" | "CUSTOM_EXCEPTION";
+      errorCode?: string;
+      data: string;
+    };
+  };
+  responses: never;
+  parameters: never;
+  requestBodies: never;
+  headers: never;
+  pathItems: never;
 }
 
 export type $defs = Record<string, never>;
@@ -759,896 +751,897 @@ export type $defs = Record<string, never>;
 export type external = Record<string, never>;
 
 export interface operations {
-	/** 댓글 수정 */
-	modify: {
-		parameters: {
-			path: {
-				postId: number;
-				commentId: number;
-			};
-		};
-		requestBody: {
-			content: {
-				'application/json': components['schemas']['Register'];
-			};
-		};
-		responses: {
-			/** @description OK */
-			200: {
-				content: never;
-			};
-		};
-	};
-	/** 댓글 삭제 */
-	delete: {
-		parameters: {
-			path: {
-				postId: number;
-				commentId: number;
-			};
-		};
-		responses: {
-			/** @description OK */
-			200: {
-				content: never;
-			};
-		};
-	};
-	/** 알림 읽음 처리 */
-	read: {
-		parameters: {
-			path: {
-				id: number;
-			};
-		};
-		responses: {
-			/** @description OK */
-			200: {
-				content: never;
-			};
-		};
-	};
-	/** 내 정보 조회 */
-	detailMember: {
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponseMemberDto'];
-				};
-			};
-		};
-	};
-	/** 내 정보 수정 */
-	modifyMember: {
-		requestBody: {
-			content: {
-				'application/json': components['schemas']['Modify'];
-			};
-		};
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponseEmpty'];
-				};
-			};
-		};
-	};
-	/** 최초 소셜로그인 - 필수 회원정보 입력 */
-	updateSocialMember: {
-		requestBody: {
-			content: {
-				'application/json': components['schemas']['SocialProfileForm'];
-			};
-		};
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponseMemberDto'];
-				};
-			};
-		};
-	};
-	/** 구인공고 단건 조회 */
-	showDetailPost: {
-		parameters: {
-			path: {
-				id: number;
-			};
-		};
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponseJobPostDetailDto'];
-				};
-			};
-		};
-	};
-	/** 구인공고 수정 */
-	modifyPost: {
-		parameters: {
-			path: {
-				id: number;
-			};
-		};
-		requestBody: {
-			content: {
-				'application/json': components['schemas']['Modify'];
-			};
-		};
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponseModify'];
-				};
-			};
-		};
-	};
-	/** 구인공고 삭제 */
-	deleteJobPost: {
-		parameters: {
-			path: {
-				id: number;
-			};
-		};
-		responses: {
-			/** @description OK */
-			200: {
-				content: never;
-			};
-		};
-	};
-	/** 조기 마감 */
-	postEarlyClosing: {
-		parameters: {
-			path: {
-				id: number;
-			};
-		};
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponseEmpty'];
-				};
-			};
-		};
-	};
-	/** 채팅방 입장 */
-	showRoom: {
-		parameters: {
-			path: {
-				roomId: number;
-			};
-		};
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponseRoomDto'];
-				};
-			};
-		};
-	};
-	/** 채팅방 퇴장 */
-	exitsRoom: {
-		parameters: {
-			path: {
-				roomId: number;
-			};
-		};
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponseEmpty'];
-				};
-			};
-		};
-	};
-	/** 지원서 상세 내용 */
-	detailApplication: {
-		parameters: {
-			path: {
-				id: number;
-			};
-		};
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponseApplicationDto'];
-				};
-			};
-		};
-	};
-	/** 지원서 수정 */
-	modifyApplication: {
-		parameters: {
-			path: {
-				id: number;
-			};
-		};
-		requestBody: {
-			content: {
-				'application/json': components['schemas']['Modify'];
-			};
-		};
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponseEmpty'];
-				};
-			};
-		};
-	};
-	/** 지원서 작성 */
-	writeApplication: {
-		parameters: {
-			path: {
-				id: number;
-			};
-		};
-		requestBody: {
-			content: {
-				'application/json': components['schemas']['Register'];
-			};
-		};
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponseEmpty'];
-				};
-			};
-		};
-	};
-	/** 지원서 삭제 */
-	deleteApplication: {
-		parameters: {
-			path: {
-				id: number;
-			};
-		};
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponseEmpty'];
-				};
-			};
-		};
-	};
-	runBatch: {
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': string;
-				};
-			};
-		};
-	};
-	/** 댓글 작성 */
-	write: {
-		parameters: {
-			path: {
-				postId: number;
-			};
-		};
-		requestBody: {
-			content: {
-				'application/json': components['schemas']['Register'];
-			};
-		};
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponseRegister'];
-				};
-			};
-		};
-	};
-	/** 결제 요청 */
-	requestTossPayments: {
-		requestBody: {
-			content: {
-				'application/json': components['schemas']['PaymentReqDto'];
-			};
-		};
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponsePaymentResDto'];
-				};
-			};
-		};
-	};
-	/** 결제 취소 */
-	tossPaymentCancel: {
-		parameters: {
-			query: {
-				paymentKey: string;
-				cancelReason: string;
-			};
-		};
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponsePaymentCancelResDto'];
-				};
-			};
-		};
-	};
-	register: {
-		requestBody: {
-			content: {
-				'application/json': string;
-			};
-		};
-		responses: {
-			/** @description OK */
-			200: {
-				content: never;
-			};
-		};
-	};
-	/** 지원자 리뷰 작성 */
-	createReview: {
-		parameters: {
-			path: {
-				jobPostingId: number;
-			};
-		};
-		requestBody: {
-			content: {
-				'application/json': components['schemas']['ApplicantReviewDto'];
-			};
-		};
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponseApplicantReviewDto'];
-				};
-			};
-		};
-	};
-	/** 로그아웃 처리 및 쿠키 삭제 */
-	logout: {
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': Record<string, never>;
-				};
-			};
-		};
-	};
-	/** 로그인, accessToken, refreshToken 쿠키 생성됨 */
-	login: {
-		requestBody: {
-			content: {
-				'application/json': components['schemas']['LoginForm'];
-			};
-		};
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponseMemberDto'];
-				};
-			};
-		};
-	};
-	/** 회원가입 */
-	join: {
-		requestBody: {
-			content: {
-				'application/json': components['schemas']['JoinForm'];
-			};
-		};
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponseJoinForm'];
-				};
-			};
-		};
-	};
-	/** 구인공고 글 목록 가져오기 */
-	findAllPost: {
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponseListJobPostDto'];
-				};
-			};
-		};
-	};
-	/** 구인공고 작성 */
-	writePost: {
-		requestBody: {
-			content: {
-				'application/json': components['schemas']['Register'];
-			};
-		};
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponseRegister'];
-				};
-			};
-		};
-	};
-	/** 구인공고 관심 등록 */
-	interest: {
-		parameters: {
-			path: {
-				id: number;
-			};
-		};
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponseEmpty'];
-				};
-			};
-		};
-	};
-	/** 구인공고 관심 제거 */
-	disinterest: {
-		parameters: {
-			path: {
-				id: number;
-			};
-		};
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponseEmpty'];
-				};
-			};
-		};
-	};
-	/** 채팅 메세지 로드 */
-	writeChat_1: {
-		parameters: {
-			path: {
-				roomId: number;
-			};
-		};
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponseListMessageDto'];
-				};
-			};
-		};
-	};
-	/** 채팅 생성 */
-	writeChat: {
-		parameters: {
-			path: {
-				roomId: number;
-			};
-		};
-		requestBody: {
-			content: {
-				'application/json': components['schemas']['Register'];
-			};
-		};
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponseEmpty'];
-				};
-			};
-		};
-	};
-	/** 인증 메일 전송 */
-	sendAuthEmail: {
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponseEmpty'];
-				};
-			};
-		};
-	};
-	/** 인증코드 확인 */
-	verifyCode: {
-		parameters: {
-			path: {
-				code: string;
-			};
-		};
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponseEmpty'];
-				};
-			};
-		};
-	};
-	/** 개인 지급 알바 미완료 처리 */
-	cancelIndividualNoWork: {
-		parameters: {
-			path: {
-				applicationId: number;
-			};
-		};
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponseEmpty'];
-				};
-			};
-		};
-	};
-	/** 구인자가 수동으로 알바완료 처리 */
-	completeJobManually: {
-		parameters: {
-			path: {
-				applicationId: number;
-			};
-		};
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponseEmpty'];
-				};
-			};
-		};
-	};
-	/** 지원서 승인 */
-	approve: {
-		parameters: {
-			path: {
-				postId: number;
-				applicationIds: number[];
-			};
-		};
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponseEmpty'];
-				};
-			};
-		};
-	};
-	/** 배포한 애플리케이션의 준비 상태를 확인 */
-	isReady: {
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': string;
-				};
-			};
-		};
-	};
-	/** 소셜 로그인 */
-	socialLogin: {
-		parameters: {
-			query: {
-				redirectUrl: string;
-			};
-			path: {
-				providerTypeCode: string;
-			};
-		};
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': string;
-				};
-			};
-		};
-	};
-	/** 해당 공고에 달린 댓글 목록 */
-	findByPostId: {
-		parameters: {
-			path: {
-				postId: number;
-			};
-		};
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponseListCommentDto'];
-				};
-			};
-		};
-	};
-	/** 결제정보 가져오기 */
-	getPaymentKey: {
-		parameters: {
-			path: {
-				applicationId: number;
-			};
-		};
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponsePaymentDto'];
-				};
-			};
-		};
-	};
-	/** 결제 성공 */
-	tossPaymentSuccess: {
-		parameters: {
-			query: {
-				paymentKey: string;
-				orderId: string;
-				amount: number;
-			};
-		};
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponsePaymentSuccessDto'];
-				};
-			};
-		};
-	};
-	/** 결제 실패 */
-	tossPaymentFail: {
-		parameters: {
-			query: {
-				code: string;
-				message: string;
-				orderId: string;
-			};
-		};
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponsePaymentFailDto'];
-				};
-			};
-		};
-	};
-	/** 유저 별 알림리스트 */
-	getList: {
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponseListNotificationDto'];
-				};
-			};
-		};
-	};
-	/** 읽지 않은 알림 유무 확인 */
-	unreadNotification: {
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponseBoolean'];
-				};
-			};
-		};
-	};
-	/** 나의 전체 리뷰 조회 */
-	getAllReviews: {
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponseListApplicantReviewDto'];
-				};
-			};
-		};
-	};
-	/** 리뷰 단건 조회 */
-	getReviewById: {
-		parameters: {
-			path: {
-				id: number;
-			};
-		};
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponseApplicantReviewDto'];
-				};
-			};
-		};
-	};
-	/** 리뷰 삭제 */
-	deleteReview: {
-		parameters: {
-			path: {
-				id: number;
-			};
-		};
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponseString'];
-				};
-			};
-		};
-	};
-	/** 내 공고 조회 */
-	detailMyPosts: {
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponseListJobPostDto'];
-				};
-			};
-		};
-	};
-	/** 내 관심 공고 조회 */
-	detailMyInterestingPosts: {
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponseListJobPostDto'];
-				};
-			};
-		};
-	};
-	/** 내 댓글 조회 */
-	detailMyComments: {
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponseListCommentDto'];
-				};
-			};
-		};
-	};
-	/** 내 지원서 조회 */
-	detailMyApplications: {
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponseListApplicationDto'];
-				};
-			};
-		};
-	};
-	/** 로그인한 유저의 해당 구인공고 관심 등록 여부 */
-	isInterested: {
-		parameters: {
-			path: {
-				id: number;
-			};
-		};
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponseBoolean'];
-				};
-			};
-		};
-	};
-	/** 구인공고 글 목록 정렬 */
-	findAllPostSort: {
-		parameters: {
-			query?: {
-				page?: number;
-				sortBy?: string[];
-				sortOrder?: string[];
-			};
-		};
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponseGetPostsResponseBody'];
-				};
-			};
-		};
-	};
-	/** 게시물 검색 */
-	searchJobPostsByTitleAndBody: {
-		parameters: {
-			query?: {
-				titleOrBody?: string;
-				title?: string;
-				body?: string;
-			};
-		};
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponseListJobPostDto'];
-				};
-			};
-		};
-	};
-	/** 공고 별 지원리스트 */
-	getList_1: {
-		parameters: {
-			path: {
-				postId: number;
-			};
-		};
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponseListApplicationDto'];
-				};
-			};
-		};
-	};
-	/** 채팅방 목록 */
-	showRoomList: {
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': components['schemas']['ApiResponseListRoomListDto'];
-				};
-			};
-		};
-	};
-	showMain: {
-		responses: {
-			/** @description OK */
-			200: {
-				content: {
-					'*/*': string;
-				};
-			};
-		};
-	};
-	/** 읽은 알림 전부 삭제 */
-	deleteReadAll: {
-		responses: {
-			/** @description OK */
-			200: {
-				content: never;
-			};
-		};
-	};
-	/** 알림 전부 삭제 */
-	deleteAll: {
-		responses: {
-			/** @description OK */
-			200: {
-				content: never;
-			};
-		};
-	};
+
+  /** 댓글 수정 */
+  modify: {
+    parameters: {
+      path: {
+        postId: number;
+        commentId: number;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["Register"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: never;
+      };
+    };
+  };
+  /** 댓글 삭제 */
+  delete: {
+    parameters: {
+      path: {
+        postId: number;
+        commentId: number;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: never;
+      };
+    };
+  };
+  /** 알림 읽음 처리 */
+  read: {
+    parameters: {
+      path: {
+        id: number;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: never;
+      };
+    };
+  };
+  /** 내 정보 조회 */
+  detailMember: {
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseMemberDto"];
+        };
+      };
+    };
+  };
+  /** 내 정보 수정 */
+  modifyMember: {
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["Modify"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseEmpty"];
+        };
+      };
+    };
+  };
+  /** 최초 소셜로그인 - 필수 회원정보 입력 */
+  updateSocialMember: {
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["SocialProfileForm"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseMemberDto"];
+        };
+      };
+    };
+  };
+  /** 구인공고 단건 조회 */
+  showDetailPost: {
+    parameters: {
+      path: {
+        id: number;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseJobPostDetailDto"];
+        };
+      };
+    };
+  };
+  /** 구인공고 수정 */
+  modifyPost: {
+    parameters: {
+      path: {
+        id: number;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["Modify"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseModify"];
+        };
+      };
+    };
+  };
+  /** 구인공고 삭제 */
+  deleteJobPost: {
+    parameters: {
+      path: {
+        id: number;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: never;
+      };
+    };
+  };
+  /** 조기 마감 */
+  postEarlyClosing: {
+    parameters: {
+      path: {
+        id: number;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseEmpty"];
+        };
+      };
+    };
+  };
+  /** 채팅방 입장 */
+  showRoom: {
+    parameters: {
+      path: {
+        roomId: number;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseRoomDto"];
+        };
+      };
+    };
+  };
+  /** 채팅방 퇴장 */
+  exitsRoom: {
+    parameters: {
+      path: {
+        roomId: number;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseEmpty"];
+        };
+      };
+    };
+  };
+  /** 지원서 상세 내용 */
+  detailApplication: {
+    parameters: {
+      path: {
+        id: number;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseApplicationDto"];
+        };
+      };
+    };
+  };
+  /** 지원서 수정 */
+  modifyApplication: {
+    parameters: {
+      path: {
+        id: number;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["Modify"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseEmpty"];
+        };
+      };
+    };
+  };
+  /** 지원서 작성 */
+  writeApplication: {
+    parameters: {
+      path: {
+        id: number;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["Register"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseEmpty"];
+        };
+      };
+    };
+  };
+  /** 지원서 삭제 */
+  deleteApplication: {
+    parameters: {
+      path: {
+        id: number;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseEmpty"];
+        };
+      };
+    };
+  };
+  runBatch: {
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": string;
+        };
+      };
+    };
+  };
+  /** 댓글 작성 */
+  write: {
+    parameters: {
+      path: {
+        postId: number;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["Register"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseRegister"];
+        };
+      };
+    };
+  };
+  /** 결제 요청 */
+  requestTossPayments: {
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["PaymentReqDto"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponsePaymentResDto"];
+        };
+      };
+    };
+  };
+  /** 결제 취소 */
+  tossPaymentCancel: {
+    parameters: {
+      query: {
+        paymentKey: string;
+        cancelReason: string;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponsePaymentCancelResDto"];
+        };
+      };
+    };
+  };
+  register: {
+    requestBody: {
+      content: {
+        "application/json": string;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: never;
+      };
+    };
+  };
+  /** 지원자 리뷰 작성 */
+  createReview: {
+    parameters: {
+      path: {
+        jobPostingId: number;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["ApplicantReviewDto"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseApplicantReviewDto"];
+        };
+      };
+    };
+  };
+  /** 로그아웃 처리 및 쿠키 삭제 */
+  logout: {
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": Record<string, never>;
+        };
+      };
+    };
+  };
+  /** 로그인, accessToken, refreshToken 쿠키 생성됨 */
+  login: {
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["LoginForm"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseMemberDto"];
+        };
+      };
+    };
+  };
+  /** 회원가입 */
+  join: {
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["JoinForm"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseJoinForm"];
+        };
+      };
+    };
+  };
+  /** 구인공고 글 목록 가져오기 */
+  findAllPost: {
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseListJobPostDto"];
+        };
+      };
+    };
+  };
+  /** 구인공고 작성 */
+  writePost: {
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["Register"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseRegister"];
+        };
+      };
+    };
+  };
+  /** 구인공고 관심 등록 */
+  interest: {
+    parameters: {
+      path: {
+        id: number;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseEmpty"];
+        };
+      };
+    };
+  };
+  /** 구인공고 관심 제거 */
+  disinterest: {
+    parameters: {
+      path: {
+        id: number;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseEmpty"];
+        };
+      };
+    };
+  };
+  /** 채팅 메세지 로드 */
+  writeChat_1: {
+    parameters: {
+      path: {
+        roomId: number;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseListMessageDto"];
+        };
+      };
+    };
+  };
+  /** 채팅 생성 */
+  writeChat: {
+    parameters: {
+      path: {
+        roomId: number;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["Register"];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseEmpty"];
+        };
+      };
+    };
+  };
+  /** 인증 메일 전송 */
+  sendAuthEmail: {
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseEmpty"];
+        };
+      };
+    };
+  };
+  /** 인증코드 확인 */
+  verifyCode: {
+    parameters: {
+      path: {
+        code: string;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseEmpty"];
+        };
+      };
+    };
+  };
+  /** 개인 지급 알바 미완료 처리 */
+  cancelIndividualNoWork: {
+    parameters: {
+      path: {
+        applicationId: number;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseEmpty"];
+        };
+      };
+    };
+  };
+  /** 구인자가 수동으로 알바완료 처리 */
+  completeJobManually: {
+    parameters: {
+      path: {
+        applicationId: number;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseEmpty"];
+        };
+      };
+    };
+  };
+  /** 지원서 승인 */
+  approve: {
+    parameters: {
+      path: {
+        postId: number;
+        applicationIds: number[];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseEmpty"];
+        };
+      };
+    };
+  };
+  /** 배포한 애플리케이션의 준비 상태를 확인 */
+  isReady: {
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": string;
+        };
+      };
+    };
+  };
+  /** 소셜 로그인 */
+  socialLogin: {
+    parameters: {
+      query: {
+        redirectUrl: string;
+      };
+      path: {
+        providerTypeCode: string;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": string;
+        };
+      };
+    };
+  };
+  /** 해당 공고에 달린 댓글 목록 */
+  findByPostId: {
+    parameters: {
+      path: {
+        postId: number;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseListCommentDto"];
+        };
+      };
+    };
+  };
+  /** 결제정보 가져오기 */
+  getPaymentKey: {
+    parameters: {
+      path: {
+        applicationId: number;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponsePaymentDto"];
+        };
+      };
+    };
+  };
+  /** 결제 성공 */
+  tossPaymentSuccess: {
+    parameters: {
+      query: {
+        paymentKey: string;
+        orderId: string;
+        amount: number;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponsePaymentSuccessDto"];
+        };
+      };
+    };
+  };
+  /** 결제 실패 */
+  tossPaymentFail: {
+    parameters: {
+      query: {
+        code: string;
+        message: string;
+        orderId: string;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponsePaymentFailDto"];
+        };
+      };
+    };
+  };
+  /** 유저 별 알림리스트 */
+  getList: {
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseListNotificationDto"];
+        };
+      };
+    };
+  };
+  /** 읽지 않은 알림 유무 확인 */
+  unreadNotification: {
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseBoolean"];
+        };
+      };
+    };
+  };
+  /** 나의 전체 리뷰 조회 */
+  getAllReviews: {
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseListApplicantReviewDto"];
+        };
+      };
+    };
+  };
+  /** 리뷰 단건 조회 */
+  getReviewById: {
+    parameters: {
+      path: {
+        id: number;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseApplicantReviewDto"];
+        };
+      };
+    };
+  };
+  /** 리뷰 삭제 */
+  deleteReview: {
+    parameters: {
+      path: {
+        id: number;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseString"];
+        };
+      };
+    };
+  };
+  /** 내 공고 조회 */
+  detailMyPosts: {
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseListJobPostDto"];
+        };
+      };
+    };
+  };
+  /** 내 관심 공고 조회 */
+  detailMyInterestingPosts: {
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseListJobPostDto"];
+        };
+      };
+    };
+  };
+  /** 내 댓글 조회 */
+  detailMyComments: {
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseListCommentDto"];
+        };
+      };
+    };
+  };
+  /** 내 지원서 조회 */
+  detailMyApplications: {
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseListApplicationDto"];
+        };
+      };
+    };
+  };
+  /** 로그인한 유저의 해당 구인공고 관심 등록 여부 */
+  isInterested: {
+    parameters: {
+      path: {
+        id: number;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseBoolean"];
+        };
+      };
+    };
+  };
+  /** 구인공고 글 목록 정렬 */
+  findAllPostSort: {
+    parameters: {
+      query?: {
+        page?: number;
+        sortBy?: string[];
+        sortOrder?: string[];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseGetPostsResponseBody"];
+        };
+      };
+    };
+  };
+  /** 게시물 검색 */
+  searchJobPostsByTitleAndBody: {
+    parameters: {
+      query?: {
+        titleOrBody?: string;
+        title?: string;
+        body?: string;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseListJobPostDto"];
+        };
+      };
+    };
+  };
+  /** 공고 별 지원리스트 */
+  getList_1: {
+    parameters: {
+      path: {
+        postId: number;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseListApplicationDto"];
+        };
+      };
+    };
+  };
+  /** 채팅방 목록 */
+  showRoomList: {
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseListRoomListDto"];
+        };
+      };
+    };
+  };
+  showMain: {
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": string;
+        };
+      };
+    };
+  };
+  /** 읽은 알림 전부 삭제 */
+  deleteReadAll: {
+    responses: {
+      /** @description OK */
+      200: {
+        content: never;
+      };
+    };
+  };
+  /** 알림 전부 삭제 */
+  deleteAll: {
+    responses: {
+      /** @description OK */
+      200: {
+        content: never;
+      };
+    };
+  };
 }

--- a/front/src/lib/types/api/v1/schema.d.ts
+++ b/front/src/lib/types/api/v1/schema.d.ts
@@ -15,6 +15,10 @@ export interface paths {
     /** 알림 읽음 처리 */
     put: operations["read"];
   };
+  "/api/members/image": {
+    /** 프로필 이미지 변경 */
+    put: operations["updateMemberImage"];
+  };
   "/api/member": {
     /** 내 정보 조회 */
     get: operations["detailMember"];
@@ -157,6 +161,14 @@ export interface paths {
     /** 읽지 않은 알림 유무 확인 */
     get: operations["unreadNotification"];
   };
+  "/api/members/image/{username}": {
+    /** 아이디로 프로필 이미지 URL 불러오기 */
+    get: operations["getMemberImageByUsername"];
+  };
+  "/api/members/image/posts/{postId}": {
+    /** 공고번호로 작성자의 프로필 이미지 URL 불러오기 */
+    get: operations["getMemberImageByPostId"];
+  };
   "/api/member/review": {
     /** 나의 전체 리뷰 조회 */
     get: operations["getAllReviews"];
@@ -223,14 +235,6 @@ export interface components {
     Register: {
       content: string;
     };
-    Modify: {
-      /** @enum {string} */
-      gender?: "MALE" | "FEMALE" | "UNDEFINED";
-      location?: string;
-      /** Format: date */
-      birth?: string;
-      password?: string;
-    };
     ApiResponseEmpty: {
       /** Format: int32 */
       statusCode?: number;
@@ -241,6 +245,14 @@ export interface components {
       data: components["schemas"]["Empty"];
     };
     Empty: Record<string, never>;
+    Modify: {
+      /** @enum {string} */
+      gender?: "MALE" | "FEMALE" | "UNDEFINED";
+      location?: string;
+      /** Format: date */
+      birth?: string;
+      password?: string;
+    };
     SocialProfileForm: {
       name: string;
       phoneNumber: string;
@@ -511,6 +523,15 @@ export interface components {
       errorCode?: string;
       data: boolean;
     };
+    ApiResponseString: {
+      /** Format: int32 */
+      statusCode?: number;
+      message: string;
+      /** @enum {string} */
+      resultType: "SUCCESS" | "VALIDATION_EXCEPTION" | "CUSTOM_EXCEPTION";
+      errorCode?: string;
+      data: string;
+    };
     ApiResponseListApplicantReviewDto: {
       /** Format: int32 */
       statusCode?: number;
@@ -728,15 +749,6 @@ export interface components {
       errorCode?: string;
       data: components["schemas"]["ApplicationDto"];
     };
-    ApiResponseString: {
-      /** Format: int32 */
-      statusCode?: number;
-      message: string;
-      /** @enum {string} */
-      resultType: "SUCCESS" | "VALIDATION_EXCEPTION" | "CUSTOM_EXCEPTION";
-      errorCode?: string;
-      data: string;
-    };
   };
   responses: never;
   parameters: never;
@@ -797,6 +809,25 @@ export interface operations {
       /** @description OK */
       200: {
         content: never;
+      };
+    };
+  };
+  /** 프로필 이미지 변경 */
+  updateMemberImage: {
+    requestBody?: {
+      content: {
+        "application/json": {
+          /** Format: binary */
+          profileImageFile?: string;
+        };
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseEmpty"];
+        };
       };
     };
   };
@@ -1445,6 +1476,38 @@ export interface operations {
       200: {
         content: {
           "*/*": components["schemas"]["ApiResponseBoolean"];
+        };
+      };
+    };
+  };
+  /** 아이디로 프로필 이미지 URL 불러오기 */
+  getMemberImageByUsername: {
+    parameters: {
+      path: {
+        username: string;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseString"];
+        };
+      };
+    };
+  };
+  /** 공고번호로 작성자의 프로필 이미지 URL 불러오기 */
+  getMemberImageByPostId: {
+    parameters: {
+      path: {
+        postId: number;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          "*/*": components["schemas"]["ApiResponseString"];
         };
       };
     };

--- a/front/src/lib/types/api/v1/schema.d.ts
+++ b/front/src/lib/types/api/v1/schema.d.ts
@@ -249,8 +249,6 @@ export interface components {
       location: string;
       /** Format: date */
       birth: string;
-      /** Format: binary */
-      image?: string;
     };
     ApiResponseMemberDto: {
       /** Format: int32 */
@@ -274,6 +272,7 @@ export interface components {
       phoneNumber: string;
       email: string;
       authenticated?: boolean;
+      profileImageUrl?: string;
     };
     ApiResponseModify: {
       /** Format: int32 */

--- a/front/src/routes/job-post/[id]/+page.svelte
+++ b/front/src/routes/job-post/[id]/+page.svelte
@@ -16,7 +16,7 @@
 		// 공고 작성자 프로필 이미지 URL 로드
 		const response = await rq.apiEndPoints().GET(`/api/members/image/posts/${postId}`);
 		jobPostProfileImageUrl = response.data?.data;
-		rq.msgInfo(jobPostProfileImageUrl);
+
 		await loadComments(); // 댓글 로드
 
 		if (rq.isLogin()) {
@@ -174,7 +174,7 @@
 		<div class="container mx-auto px-4">
 			<div class="p-6 max-w-4xl mx-auto my-5 bg-white rounded-box shadow-lg">
 				<div class="flex">
-					<div class="avatar online placeholder">
+					<div class="avatar placeholder">
 						<div class="bg-neutral text-neutral-content rounded-full w-8">
 							{#if jobPostProfileImageUrl != null}
 								<img src={jobPostProfileImageUrl} alt="프로필 사진" />
@@ -436,9 +436,13 @@
 							<div class="p-4 rounded-lg bg-base-100 shadow">
 								<div class="flex items-center justify-between mb-2">
 									<div class="flex items-center space-x-2">
-										<div class="avatar online placeholder">
+										<div class="avatar placeholder">
 											<div class="bg-neutral text-neutral-content rounded-full w-8">
-												<span class="text-xs">{comment.author.slice(0, 3)}</span>
+												{#if comment.authorProfileImageUrl != null}
+													<img src={comment.authorProfileImageUrl} alt={comment.author} />
+												{:else}
+													<span class="text-xs">{comment.author.slice(0, 3)}</span>
+												{/if}
 											</div>
 										</div>
 										<div>

--- a/front/src/routes/job-post/[id]/+page.svelte
+++ b/front/src/routes/job-post/[id]/+page.svelte
@@ -9,8 +9,16 @@
 	let newComment = '';
 	let editingContent = '';
 	let interested = false;
+	let jobPostProfileImageUrl = null;
+
 	onMount(async () => {
+		const postId = parseInt($page.params.id);
+		// 공고 작성자 프로필 이미지 URL 로드
+		const response = await rq.apiEndPoints().GET(`/api/members/image/posts/${postId}`);
+		jobPostProfileImageUrl = response.data?.data;
+		rq.msgInfo(jobPostProfileImageUrl);
 		await loadComments(); // 댓글 로드
+
 		if (rq.isLogin()) {
 			await updateInterestStatus(); // 관심등록 여부 확인 및 상태 업데이트
 		}
@@ -30,10 +38,10 @@
 				rq.goTo('/member/login');
 				return;
 			}
-			const postId = parseInt($page.params.id);
+
 			rq.goTo(`/applications/${postId}/write`);
 		} catch (error) {
-			console.error('애플리케이션 작성 중 오류가 발생했습니다:', error);
+			console.error('오류가 발생했습니다:', error);
 		}
 	}
 	function editPost() {
@@ -168,7 +176,11 @@
 				<div class="flex">
 					<div class="avatar online placeholder">
 						<div class="bg-neutral text-neutral-content rounded-full w-8">
-							<span class="text-xs">{jobPostDetailDto?.author.slice(0, 3)}</span>
+							{#if jobPostProfileImageUrl != null}
+								<img src={jobPostProfileImageUrl} alt="프로필 사진" />
+							{:else}
+								<span class="text-xs">{jobPostDetailDto?.author.slice(0, 3)}</span>
+							{/if}
 						</div>
 					</div>
 					<div class="text-md flex items-center mx-2">{jobPostDetailDto?.author}</div>

--- a/front/src/routes/member/me/+page.svelte
+++ b/front/src/routes/member/me/+page.svelte
@@ -6,6 +6,9 @@
 	let authCode = '';
 	let showSendEmailModal = false;
 	let showVerifyCodeModal = false;
+	let profileImageFile: File | null = null;
+	let imagePreviewUrl = '';
+	let currentProfileImageUrl = '';
 
 	function navigateToChatRoomListPage() {
 		rq.goTo('/chat/list');
@@ -19,6 +22,8 @@
 				rq.goTo('/member/login');
 				return;
 			}
+
+			currentProfileImageUrl = rq.member.profileImageUrl || '';
 			loadMyReview();
 		} catch (error) {
 			console.error('인증 초기화 중 오류 발생:', error);
@@ -131,6 +136,52 @@
 		showSendEmailModal = false;
 		showVerifyCodeModal = false;
 	}
+
+	function handleImageChange(event: Event) {
+		const input = event.target as HTMLInputElement;
+		if (input.files && input.files[0]) {
+			profileImageFile = input.files[0];
+			imagePreviewUrl = URL.createObjectURL(profileImageFile);
+		}
+	}
+
+	async function updateProfileImage() {
+		if (!profileImageFile) {
+			alert('프로필 사진을 선택해주세요.');
+			return;
+		}
+
+		// FormData 객체 생성 및 파일 추가
+		const formData = new FormData();
+		formData.append('profileImageFile', profileImageFile);
+
+		console.log('Uploading file:', profileImageFile); // 파일 객체 로그 찍기
+		console.log('FormData entries:', Array.from(formData.entries())); // FormData 내용 확인
+
+		try {
+			// rq.apiEndPoints() 대신 직접 fetch 사용
+			const response = await fetch('http://localhost:8090/api/members/image', {
+				method: 'PUT',
+				body: formData,
+				credentials: 'include' // 쿠키가 필요한 경우
+			});
+
+			const responseData = await response.json(); // 응답을 JSON 형태로 파싱
+			console.log('Server response:', responseData); // 서버 응답 로그 찍기
+
+			if (responseData.resultType === 'SUCCESS') {
+				rq.msgInfo('프로필 이미지가 성공적으로 업데이트되었습니다.');
+				location.reload();
+			} else if (responseData.resultType === 'CUSTOM_EXCEPTION') {
+				rq.msgError(responseData.message);
+			} else {
+				rq.msgError('프로필 이미지 업데이트를 실패하였습니다.');
+			}
+		} catch (error) {
+			console.error('Error during profile image update:', error); // 에러 로그 찍기
+			rq.msgError('에러가 발생하였습니다.');
+		}
+	}
 </script>
 
 <div class="flex justify-center items-center min-h-screen bg-base-100">
@@ -144,7 +195,6 @@
 						class="text-xs px-4 py-1 rounded-md bg-green3 text-white hover:bg-green6 transition-colors duration-150 ease-in-out"
 						on:click={navigateToChatRoomListPage}>채팅방 이동</button
 					>
-
 					{#if !rq.member.authenticated && rq.member.email != null}
 						<button
 							class="text-xs px-4 py-1 rounded-md bg-green3 text-white hover:bg-green6 transition-colors duration-150 ease-in-out"
@@ -156,8 +206,56 @@
 			<div class="border-t-2 border-gray-200 my-6"></div>
 			<div class="grid grid-cols-1 gap-2 pl-2 pr-8">
 				<div class="flex items-center justify-between bg-gray-50 px-4 py-3">
-					<div class="text-xs font-medium text-gray-600">아이디</div>
-					<div class="ml-4 text-xs font-bold text-gray-500">{rq.member.username}</div>
+					<div class="flex items-center space-x-4">
+						{#if currentProfileImageUrl == ''}
+							<div class="avatar">
+								<button
+									type="button"
+									class="w-12 h-12 rounded-full bg-gray-200 flex items-center justify-center cursor-pointer"
+									on:click={() => document.getElementById('profileImageFile').click()}
+									on:keydown={(e) => {
+										if (e.key === 'Enter' || e.key === ' ') {
+											document.getElementById('profileImageFile').click();
+										}
+									}}
+									role="button"
+									tabindex="0"
+								>
+									<svg
+										xmlns="http://www.w3.org/2000/svg"
+										class="h-6 w-6 text-gray-600"
+										fill="none"
+										viewBox="0 0 24 24"
+										stroke="currentColor"
+									>
+										<path
+											stroke-linecap="round"
+											stroke-linejoin="round"
+											stroke-width="2"
+											d="M12 6v6m0 0v6m0-6h6m-6 0H6"
+										/>
+									</svg>
+								</button>
+							</div>
+							<input
+								id="profileImageFile"
+								type="file"
+								accept="image/*"
+								class="hidden"
+								on:change={handleImageChange}
+							/>
+						{:else}
+							<div class="avatar">
+								<div class="w-12 rounded-full ring ring-primary ring-offset-base-100 ring-offset-2">
+									<img src={currentProfileImageUrl} alt="프로필 사진" />
+								</div>
+							</div>
+						{/if}
+					</div>
+					<div class="flex items-center space-x-6">
+						<div class="text-sm font-medium text-gray-600">ID :</div>
+						<div class="text-sm font-bold text-gray-500">{rq.member.username}</div>
+					</div>
 				</div>
 				<div class="flex items-center justify-between bg-gray-50 px-4 py-3">
 					<div class="text-xs font-medium text-gray-500">이름</div>
@@ -193,6 +291,83 @@
 					>
 				</div>
 			</div>
+
+			<!-- 프로필 사진 미리보기 모달 -->
+			{#if imagePreviewUrl}
+				<div class="fixed z-10 inset-0 overflow-y-auto">
+					<div
+						class="flex items-center justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0"
+					>
+						<div class="fixed inset-0 transition-opacity" aria-hidden="true">
+							<div class="absolute inset-0 bg-gray-500 opacity-75"></div>
+						</div>
+						<span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true"
+							>​</span
+						>
+						<div
+							class="inline-block align-middle bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:max-w-lg sm:w-full"
+							role="dialog"
+							aria-modal="true"
+							aria-labelledby="modal-headline"
+						>
+							<div class="bg-white px-6 pt-5 pb-4 sm:p-6 sm:pb-4">
+								<div class="sm:flex sm:items-center">
+									<div
+										class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-green-100 sm:mx-0 sm:h-10 sm:w-10"
+									>
+										<svg
+											class="h-6 w-6 text-green-600"
+											xmlns="http://www.w3.org/2000/svg"
+											fill="none"
+											viewBox="0 0 24 24"
+											stroke="currentColor"
+											aria-hidden="true"
+										>
+											<path
+												stroke-linecap="round"
+												stroke-linejoin="round"
+												stroke-width="2"
+												d="M5 13l4 4L19 7"
+											/>
+										</svg>
+									</div>
+									<div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+										<h3 class="text-md leading-6 font-medium text-gray-800" id="modal-headline">
+											프로필 사진 미리보기
+										</h3>
+										<div class="mt-2">
+											<div class="flex justify-center">
+												<div class="avatar">
+													<div class="rounded-full w-24 h-24">
+														<img src={imagePreviewUrl} alt="프로필 사진 미리보기" />
+													</div>
+												</div>
+											</div>
+										</div>
+									</div>
+								</div>
+							</div>
+							<div class="bg-gray-50 px-6 py-3 sm:px-6 flex justify-between">
+								<button
+									type="button"
+									class="inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-green-600 text-base font-medium text-white hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 w-auto text-sm"
+									on:click={updateProfileImage}
+								>
+									업로드
+								</button>
+								<button
+									type="button"
+									class="inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 w-auto text-sm"
+									on:click={() => (imagePreviewUrl = '')}
+								>
+									취소
+								</button>
+							</div>
+						</div>
+					</div>
+				</div>
+			{/if}
+
 			<div class="border-t-2 border-gray-200 my-6"></div>
 			<div class="flex justify-center">
 				<div class="join flex flex-wrap gap-4 justify-around">

--- a/front/tailwind.config.js
+++ b/front/tailwind.config.js
@@ -19,5 +19,16 @@ export default {
 			}
 		}
 	},
-	plugins: [require('daisyui')]
+	plugins: [require('daisyui')],
+	daisyui: {
+		themes: [
+			{
+				mytheme: {
+					primary: '#78db4a',
+					'primary-focus': '#3bbe2a',
+					'primary-content': '#ffffff'
+				}
+			}
+		]
+	}
 };

--- a/src/main/java/com/ll/gooHaeYu/domain/fileupload/S3ImageService.java
+++ b/src/main/java/com/ll/gooHaeYu/domain/fileupload/S3ImageService.java
@@ -1,0 +1,123 @@
+package com.ll.gooHaeYu.domain.fileupload;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.util.IOUtils;
+import com.ll.gooHaeYu.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+import static com.ll.gooHaeYu.global.exception.ErrorCode.*;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class S3ImageService {
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucketName}")
+    private String bucketName;
+
+    // 이미지 업로드 (S3에 저장된 이미지 객체의 public url 반환)
+    public String upload(MultipartFile image) {
+        // 이미지가 비어 있거나 파일명이 null이면 예외 발생
+        if (image.isEmpty() || Objects.isNull(image.getOriginalFilename())) {
+            throw new CustomException(FILE_IS_EMPTY);
+        }
+        return uploadImage(image);   // 이미지 업로드 메서드 호출
+    }
+
+    // 이미지 업로드 수행
+    private String uploadImage(MultipartFile image) {
+        validateImageFileExtension(image.getOriginalFilename());   // 이미지 확장자 유효성 검사
+        try {
+            return uploadImageToS3(image);   // AWS S3에 이미지 업로드
+        } catch (IOException e) {
+            throw new CustomException(IO_EXCEPTION_ON_IMAGE_DELETE);
+        }
+    }
+
+    // 이미지 파일 확장자 유효성 검사
+    private void validateImageFileExtension(String filename) {
+        int lastDotIndex = filename.lastIndexOf(".");
+        if (lastDotIndex == -1) {   // 파일명에 점이 없으면 예외 발생
+            throw new CustomException(NO_FILE_EXTENSION);
+        }
+
+        String extension = filename.substring(lastDotIndex + 1).toLowerCase();   // 확장자를 추출하여 소문자로 변환
+        List<String> allowedExtensionList = Arrays.asList("jpg", "jpeg", "png", "gif");
+
+        if (!allowedExtensionList.contains(extension)) {   // 허용된 확장자 목록에 속하지 않으면 예외 발생
+            throw new CustomException(INVALID_FILE_EXTENSION);
+        }
+    }
+
+    // AWS S3에 이미지 업로드
+    private String uploadImageToS3(MultipartFile image) throws IOException {
+        String originalFilename = image.getOriginalFilename();   // 원본 파일명
+        String extension = originalFilename.substring(originalFilename.lastIndexOf("."));  // 확장자
+
+        String s3FileName = UUID.randomUUID().toString().substring(0, 10) + originalFilename;  // S3에 저장될 파일명
+
+        InputStream inputStream = image.getInputStream();
+        byte[] bytes = IOUtils.toByteArray(inputStream);  // 이미지 데이터를 바이트 배열로 변환
+
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType("image/" + extension);  // 메타데이터 설정
+        metadata.setContentLength(bytes.length);
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
+
+        try {
+            PutObjectRequest putObjectRequest =
+                    new PutObjectRequest(bucketName, s3FileName, byteArrayInputStream, metadata)
+                            .withCannedAcl(CannedAccessControlList.PublicRead);  // S3에 이미지 업로드 요청
+            amazonS3.putObject(putObjectRequest);
+        } catch (Exception e) {
+            throw new CustomException(PUT_OBJECT_EXCEPTION);
+        } finally {
+            byteArrayInputStream.close();
+            inputStream.close();
+        }
+
+        return amazonS3.getUrl(bucketName, s3FileName).toString();   // 업로드된 이미지의 URL 반환
+    }
+
+    // AWS S3에서 이미지 삭제
+    public void deleteImageFromS3(String imageAddress) {
+        String key = getKeyFromImageAddress(imageAddress);   // 이미지 주소에서 파일명 추출
+        try {
+            amazonS3.deleteObject(new DeleteObjectRequest(bucketName, key));   // S3에서 이미지 삭제 요청
+        } catch (Exception e) {
+            throw new CustomException(IO_EXCEPTION_ON_IMAGE_DELETE);
+        }
+    }
+
+    // 이미지 주소로부터 파일명을 추출
+    private String getKeyFromImageAddress(String imageAddress) {
+        try {
+            URL url = new URL(imageAddress);
+            String decodingKey = URLDecoder.decode(url.getPath(), "UTF-8");
+            return decodingKey.substring(1);  // 맨 앞의 '/' 제거
+        } catch (MalformedURLException | UnsupportedEncodingException e) {
+            throw new CustomException(IO_EXCEPTION_ON_IMAGE_DELETE);
+        }
+    }
+}

--- a/src/main/java/com/ll/gooHaeYu/domain/fileupload/S3ImageService.java
+++ b/src/main/java/com/ll/gooHaeYu/domain/fileupload/S3ImageService.java
@@ -16,10 +16,10 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -47,7 +47,7 @@ public class S3ImageService {
 
     // 이미지 업로드 수행
     private String uploadImage(MultipartFile image) {
-        validateImageFileExtension(image.getOriginalFilename());   // 이미지 확장자 유효성 검사
+        validateImageFileExtension(Objects.requireNonNull(image.getOriginalFilename()));   // 이미지 확장자 유효성 검사
         try {
             return uploadImageToS3(image);   // AWS S3에 이미지 업로드
         } catch (IOException e) {
@@ -73,7 +73,7 @@ public class S3ImageService {
     // AWS S3에 이미지 업로드
     private String uploadImageToS3(MultipartFile image) throws IOException {
         String originalFilename = image.getOriginalFilename();   // 원본 파일명
-        String extension = originalFilename.substring(originalFilename.lastIndexOf("."));  // 확장자
+        String extension = Objects.requireNonNull(originalFilename).substring(originalFilename.lastIndexOf("."));  // 확장자
 
         String s3FileName = UUID.randomUUID().toString().substring(0, 10) + originalFilename;  // S3에 저장될 파일명
 
@@ -113,10 +113,10 @@ public class S3ImageService {
     // 이미지 주소로부터 파일명을 추출
     private String getKeyFromImageAddress(String imageAddress) {
         try {
-            URL url = new URL(imageAddress);
-            String decodingKey = URLDecoder.decode(url.getPath(), "UTF-8");
+            URI uri = new URI(imageAddress);
+            String decodingKey = URLDecoder.decode(uri.getPath(), StandardCharsets.UTF_8);
             return decodingKey.substring(1);  // 맨 앞의 '/' 제거
-        } catch (MalformedURLException | UnsupportedEncodingException e) {
+        } catch (URISyntaxException e) {
             throw new CustomException(IO_EXCEPTION_ON_IMAGE_DELETE);
         }
     }

--- a/src/main/java/com/ll/gooHaeYu/domain/fileupload/controller/S3ImageController.java
+++ b/src/main/java/com/ll/gooHaeYu/domain/fileupload/controller/S3ImageController.java
@@ -1,0 +1,36 @@
+package com.ll.gooHaeYu.domain.fileupload.controller;
+
+import com.ll.gooHaeYu.domain.fileupload.service.ProfileImageService;
+import com.ll.gooHaeYu.global.apiResponse.ApiResponse;
+import com.ll.gooHaeYu.global.security.MemberDetails;
+import com.ll.gooHaeYu.standard.base.Empty;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+public class S3ImageController {
+    private final ProfileImageService profileImageService;
+
+    @PutMapping(value = "/api/members/image")
+    @Operation(summary = "프로필 이미지 변경")
+    public ApiResponse<Empty> updateMemberImage(@AuthenticationPrincipal MemberDetails memberDetails,
+                                                @RequestPart(value = "profileImageFile", required = false) MultipartFile profileImageFile) {
+        profileImageService.uploadProfileImage(memberDetails.getUsername(), profileImageFile);
+
+        return ApiResponse.noContent();
+    }
+
+    @GetMapping(value = "/api/members/image")
+    @Operation(summary = "프로필 이미지 URL 불러오기")
+    public ApiResponse<String> getMemberImage(@AuthenticationPrincipal MemberDetails memberDetails) {
+
+        return ApiResponse.ok(profileImageService.getProfileImage(memberDetails.getUsername()));
+    }
+}

--- a/src/main/java/com/ll/gooHaeYu/domain/fileupload/controller/S3ImageController.java
+++ b/src/main/java/com/ll/gooHaeYu/domain/fileupload/controller/S3ImageController.java
@@ -5,14 +5,13 @@ import com.ll.gooHaeYu.global.apiResponse.ApiResponse;
 import com.ll.gooHaeYu.global.security.MemberDetails;
 import com.ll.gooHaeYu.standard.base.Empty;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+@Tag(name = "S3-Image", description = "이미지 업로드 관련 API")
 @RestController
 @RequiredArgsConstructor
 public class S3ImageController {
@@ -27,10 +26,17 @@ public class S3ImageController {
         return ApiResponse.noContent();
     }
 
-    @GetMapping(value = "/api/members/image")
-    @Operation(summary = "프로필 이미지 URL 불러오기")
-    public ApiResponse<String> getMemberImage(String username) {
+    @GetMapping(value = "/api/members/image/{username}")
+    @Operation(summary = "아이디로 프로필 이미지 URL 불러오기")
+    public ApiResponse<String> getMemberImageByUsername(@PathVariable(name = "username") String username) {
 
-        return ApiResponse.ok(profileImageService.getProfileImage(username));
+        return ApiResponse.ok(profileImageService.getMemberImageByUsername(username));
+    }
+
+    @GetMapping(value = "/api/members/image/posts/{postId}")
+    @Operation(summary = "공고번호로 작성자의 프로필 이미지 URL 불러오기")
+    public ApiResponse<String> getMemberImageByPostId(@PathVariable(name = "postId") Long postId) {
+
+        return ApiResponse.ok(profileImageService.getMemberImageByPostId(postId));
     }
 }

--- a/src/main/java/com/ll/gooHaeYu/domain/fileupload/controller/S3ImageController.java
+++ b/src/main/java/com/ll/gooHaeYu/domain/fileupload/controller/S3ImageController.java
@@ -29,8 +29,8 @@ public class S3ImageController {
 
     @GetMapping(value = "/api/members/image")
     @Operation(summary = "프로필 이미지 URL 불러오기")
-    public ApiResponse<String> getMemberImage(@AuthenticationPrincipal MemberDetails memberDetails) {
+    public ApiResponse<String> getMemberImage(String username) {
 
-        return ApiResponse.ok(profileImageService.getProfileImage(memberDetails.getUsername()));
+        return ApiResponse.ok(profileImageService.getProfileImage(username));
     }
 }

--- a/src/main/java/com/ll/gooHaeYu/domain/fileupload/service/ProfileImageService.java
+++ b/src/main/java/com/ll/gooHaeYu/domain/fileupload/service/ProfileImageService.java
@@ -1,5 +1,6 @@
 package com.ll.gooHaeYu.domain.fileupload.service;
 
+import com.ll.gooHaeYu.domain.jobPost.jobPost.service.JobPostService;
 import com.ll.gooHaeYu.domain.member.member.entity.Member;
 import com.ll.gooHaeYu.domain.member.member.service.MemberService;
 import com.ll.gooHaeYu.global.exception.CustomException;
@@ -16,6 +17,7 @@ import static com.ll.gooHaeYu.global.exception.ErrorCode.FILE_IS_EMPTY;
 public class ProfileImageService {
     private final MemberService memberService;
     private final S3ImageService s3ImageService;
+    private final JobPostService jobPostService;
 
     @Transactional
     public void uploadProfileImage(String username, MultipartFile profileImageFile) {
@@ -33,8 +35,14 @@ public class ProfileImageService {
         member.setImageUrl(imageUrl);
     }
 
-    public String getProfileImage(String username) {
+    public String getMemberImageByUsername(String username) {
         Member member = memberService.getMember(username);
+
+        return member.getProfileImageUrl();
+    }
+
+    public String getMemberImageByPostId(Long postId) {
+        Member member = jobPostService.findByIdAndValidate(postId).getMember();
 
         return member.getProfileImageUrl();
     }

--- a/src/main/java/com/ll/gooHaeYu/domain/fileupload/service/ProfileImageService.java
+++ b/src/main/java/com/ll/gooHaeYu/domain/fileupload/service/ProfileImageService.java
@@ -9,7 +9,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import static com.ll.gooHaeYu.global.exception.ErrorCode.FILE_IS_EMPTY;
-import static com.ll.gooHaeYu.global.exception.ErrorCode.PROFILE_IMAGE_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -36,10 +35,6 @@ public class ProfileImageService {
 
     public String getProfileImage(String username) {
         Member member = memberService.getMember(username);
-
-        if (member.getProfileImageUrl() == null) {
-            throw new CustomException(PROFILE_IMAGE_NOT_FOUND);
-        }
 
         return member.getProfileImageUrl();
     }

--- a/src/main/java/com/ll/gooHaeYu/domain/fileupload/service/ProfileImageService.java
+++ b/src/main/java/com/ll/gooHaeYu/domain/fileupload/service/ProfileImageService.java
@@ -1,0 +1,46 @@
+package com.ll.gooHaeYu.domain.fileupload.service;
+
+import com.ll.gooHaeYu.domain.member.member.entity.Member;
+import com.ll.gooHaeYu.domain.member.member.service.MemberService;
+import com.ll.gooHaeYu.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import static com.ll.gooHaeYu.global.exception.ErrorCode.FILE_IS_EMPTY;
+import static com.ll.gooHaeYu.global.exception.ErrorCode.PROFILE_IMAGE_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProfileImageService {
+    private final MemberService memberService;
+    private final S3ImageService s3ImageService;
+
+    @Transactional
+    public void uploadProfileImage(String username, MultipartFile profileImageFile) {
+        Member member = memberService.getMember(username);
+
+        if (profileImageFile == null ||  profileImageFile.isEmpty()) {
+            throw new CustomException(FILE_IS_EMPTY);
+        }
+
+        if (member.getProfileImageUrl() != null) {
+            s3ImageService.deleteImageFromS3(member.getProfileImageUrl());   // 기존의 프로필 이미지 파일을 S3에서 제거
+        }
+
+        String imageUrl = s3ImageService.upload(profileImageFile);
+        member.setImageUrl(imageUrl);
+    }
+
+    public String getProfileImage(String username) {
+        Member member = memberService.getMember(username);
+
+        if (member.getProfileImageUrl() == null) {
+            throw new CustomException(PROFILE_IMAGE_NOT_FOUND);
+        }
+
+        return member.getProfileImageUrl();
+    }
+}

--- a/src/main/java/com/ll/gooHaeYu/domain/jobPost/comment/dto/CommentDto.java
+++ b/src/main/java/com/ll/gooHaeYu/domain/jobPost/comment/dto/CommentDto.java
@@ -24,6 +24,7 @@ public class CommentDto {
     private String author;
     @NotBlank
     private String content;
+    private String authorProfileImageUrl;
     @NotNull
     private LocalDateTime createAt;
     @NotNull
@@ -35,6 +36,7 @@ public class CommentDto {
                 .jobPostId(comment.getJobPostDetail().getJobPost().getId())
                 .author(comment.getMember().getUsername())
                 .content(comment.getContent())
+                .authorProfileImageUrl(comment.getMember().getProfileImageUrl())
                 .createAt(comment.getCreatedAt())
                 .modifyAt(comment.getModifiedAt())
                 .build();

--- a/src/main/java/com/ll/gooHaeYu/domain/member/member/dto/MemberDto.java
+++ b/src/main/java/com/ll/gooHaeYu/domain/member/member/dto/MemberDto.java
@@ -27,6 +27,7 @@ public class MemberDto {
     @NotBlank
     private String email;
     private boolean authenticated;
+    private String profileImageUrl;
 
     public static MemberDto fromEntity(Member member) {
         return MemberDto.builder()
@@ -39,6 +40,7 @@ public class MemberDto {
                 .phoneNumber(member.getPhoneNumber())
                 .email(member.getEmail())
                 .authenticated(member.isAuthenticated())
+                .profileImageUrl(member.getProfileImageUrl())
                 .build();
     }
 }

--- a/src/main/java/com/ll/gooHaeYu/domain/member/member/dto/SocialProfileForm.java
+++ b/src/main/java/com/ll/gooHaeYu/domain/member/member/dto/SocialProfileForm.java
@@ -3,13 +3,15 @@ package com.ll.gooHaeYu.domain.member.member.dto;
 import com.ll.gooHaeYu.domain.member.member.entity.type.Gender;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.validation.constraints.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 
@@ -37,7 +39,5 @@ public class SocialProfileForm {   // JorinForm에서 username, password 제외
     @Past(message = "생년월일은 현재보다 앞선 날짜여야 합니다.")
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     private LocalDate birth;
-
-    private MultipartFile image;
 
 }

--- a/src/main/java/com/ll/gooHaeYu/domain/member/member/dto/SocialProfileForm.java
+++ b/src/main/java/com/ll/gooHaeYu/domain/member/member/dto/SocialProfileForm.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 
@@ -36,4 +37,7 @@ public class SocialProfileForm {   // JorinForm에서 username, password 제외
     @Past(message = "생년월일은 현재보다 앞선 날짜여야 합니다.")
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     private LocalDate birth;
+
+    private MultipartFile image;
+
 }

--- a/src/main/java/com/ll/gooHaeYu/domain/member/member/entity/Member.java
+++ b/src/main/java/com/ll/gooHaeYu/domain/member/member/entity/Member.java
@@ -55,7 +55,7 @@ public class Member extends BaseTimeEntity {
 
     private String FCMToken = null;
 
-    private String imageUrl;
+    private String profileImageUrl;
 
     public void update(String password, Gender gender, String location, LocalDate birth) {
         if (location != null && !location.isBlank()) {
@@ -118,7 +118,7 @@ public class Member extends BaseTimeEntity {
         this.FCMToken = null;
     }
 
-    public void setImageUrl(String imageUrl) {
-        this.imageUrl = imageUrl;
+    public void setImageUrl(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
     }
 }

--- a/src/main/java/com/ll/gooHaeYu/domain/member/member/entity/Member.java
+++ b/src/main/java/com/ll/gooHaeYu/domain/member/member/entity/Member.java
@@ -55,6 +55,8 @@ public class Member extends BaseTimeEntity {
 
     private String FCMToken = null;
 
+    private String imageUrl;
+
     public void update(String password, Gender gender, String location, LocalDate birth) {
         if (location != null && !location.isBlank()) {
             this.location = location;
@@ -114,5 +116,9 @@ public class Member extends BaseTimeEntity {
 
     public void removeFCMToken() {
         this.FCMToken = null;
+    }
+
+    public void setImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
     }
 }

--- a/src/main/java/com/ll/gooHaeYu/domain/member/member/service/MemberService.java
+++ b/src/main/java/com/ll/gooHaeYu/domain/member/member/service/MemberService.java
@@ -1,11 +1,11 @@
 package com.ll.gooHaeYu.domain.member.member.service;
 
+import com.ll.gooHaeYu.domain.fileupload.S3ImageService;
 import com.ll.gooHaeYu.domain.member.member.dto.*;
 import com.ll.gooHaeYu.domain.member.member.entity.Member;
 import com.ll.gooHaeYu.domain.member.member.entity.type.Role;
 import com.ll.gooHaeYu.domain.member.member.repository.MemberRepository;
 import com.ll.gooHaeYu.global.exception.CustomException;
-import com.ll.gooHaeYu.global.security.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -20,7 +20,7 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
-    private final JwtTokenProvider jwtTokenProvider;
+    private final S3ImageService s3ImageService;
 
     @Transactional
     public JoinForm join(JoinForm form) {
@@ -98,6 +98,7 @@ public class MemberService {
 
         member.oauthDetailUpdate(form);
         member.updateRole(Role.USER);
+        member.setImageUrl(s3ImageService.upload(form.getImage()));
 
         return MemberDto.fromEntity(member);
     }

--- a/src/main/java/com/ll/gooHaeYu/domain/member/member/service/MemberService.java
+++ b/src/main/java/com/ll/gooHaeYu/domain/member/member/service/MemberService.java
@@ -1,6 +1,5 @@
 package com.ll.gooHaeYu.domain.member.member.service;
 
-import com.ll.gooHaeYu.domain.fileupload.S3ImageService;
 import com.ll.gooHaeYu.domain.member.member.dto.*;
 import com.ll.gooHaeYu.domain.member.member.entity.Member;
 import com.ll.gooHaeYu.domain.member.member.entity.type.Role;
@@ -20,7 +19,6 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
-    private final S3ImageService s3ImageService;
 
     @Transactional
     public JoinForm join(JoinForm form) {
@@ -98,7 +96,6 @@ public class MemberService {
 
         member.oauthDetailUpdate(form);
         member.updateRole(Role.USER);
-        member.setImageUrl(s3ImageService.upload(form.getImage()));
 
         return MemberDto.fromEntity(member);
     }

--- a/src/main/java/com/ll/gooHaeYu/global/config/S3Config.java
+++ b/src/main/java/com/ll/gooHaeYu/global/config/S3Config.java
@@ -1,0 +1,32 @@
+package com.ll.gooHaeYu.global.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(region)
+                .build();
+    }
+
+}

--- a/src/main/java/com/ll/gooHaeYu/global/config/SecurityConfig.java
+++ b/src/main/java/com/ll/gooHaeYu/global/config/SecurityConfig.java
@@ -53,7 +53,9 @@ public class SecurityConfig {
                             .requestMatchers("/api/member/socialLogin/**").permitAll()
                             .requestMatchers("/oauth2/authorization/**").permitAll() // OAuth 2.0 인증 엔드포인트에 대한 접근 허용
                             .requestMatchers("/login", "/api/member/join", "api/member/login").permitAll()
-                            .requestMatchers(HttpMethod.GET, "/api/job-posts/**", "/api/job-posts", "/api/job-posts/search", "/api/post-comment/{postId}").permitAll()
+                            .requestMatchers(HttpMethod.GET, "/api/job-posts/**", "/api/job-posts", "/api/job-posts/search",
+                                    "/api/post-comment/{postId}", "/api/members/image/posts/**", "/api/members/image/**",
+                                    "/api/job-posts/{postId}/members/interest").permitAll()
                             .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
                             .anyRequest()
                             .authenticated();

--- a/src/main/java/com/ll/gooHaeYu/global/exception/ErrorCode.java
+++ b/src/main/java/com/ll/gooHaeYu/global/exception/ErrorCode.java
@@ -83,9 +83,13 @@ public enum ErrorCode {
 
     INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "유효하지 않은 파일 확장자 입니다."),
 
-    PUT_OBJECT_EXCEPTION(HttpStatus.BAD_REQUEST, "업로드 중 오류가 발생했습니다."),
+    AWS_SERVICE_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "AWS 서비스 오류가 발생했습니다."),
 
-    IO_EXCEPTION_ON_IMAGE_DELETE(HttpStatus.BAD_REQUEST, "이미지를 삭제하는 중 입출력 오류가 발생했습니다.");
+    AWS_CLIENT_EXCEPTION(HttpStatus.BAD_REQUEST, "AWS 클라이언트 요청이 잘못되었습니다."),
+
+    IO_EXCEPTION_ON_IMAGE_DELETE(HttpStatus.BAD_REQUEST, "이미지를 삭제하는 중 입출력 오류가 발생했습니다."),
+
+    PROFILE_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "프로필 이미지가 존재하지 않습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/ll/gooHaeYu/global/exception/ErrorCode.java
+++ b/src/main/java/com/ll/gooHaeYu/global/exception/ErrorCode.java
@@ -75,8 +75,17 @@ public enum ErrorCode {
 
     INVALID_AUTH_CODE(HttpStatus.BAD_REQUEST, "잘못된 인증코드 입니다."),
 
-    INITIATE_EMAIL_REQUEST(HttpStatus.BAD_REQUEST, "먼저 이메일 인증 요청을 진행해주세요.");
+    INITIATE_EMAIL_REQUEST(HttpStatus.BAD_REQUEST, "먼저 이메일 인증 요청을 진행해주세요."),
 
+    FILE_IS_EMPTY(HttpStatus.BAD_REQUEST, "파일이 비어있습니다."),
+
+    NO_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "파일 확장자가 없습니다."),
+
+    INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "유효하지 않은 파일 확장자 입니다."),
+
+    PUT_OBJECT_EXCEPTION(HttpStatus.BAD_REQUEST, "업로드 중 오류가 발생했습니다."),
+
+    IO_EXCEPTION_ON_IMAGE_DELETE(HttpStatus.BAD_REQUEST, "이미지를 삭제하는 중 입출력 오류가 발생했습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -5,10 +5,6 @@ spring:
   lifecycle:
     # 스프링부트가 종료 요청을 받은 후 기다려줄 수 있는 최대한의 시간
     timeout-per-shutdown-phase: 1h
-  servlet:
-    multipart:  # 파일 업로드 관련
-      max-file-size: 5MB
-      max-request-size: 5MB
   datasource:
     url: jdbc:mysql://172.17.0.1:3306/goohaeyou_prod
     username: root

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,10 @@ spring:
   profiles:
     active: dev
     include: secret
+  servlet:
+    multipart: # 파일 업로드 관련
+      max-file-size: 5MB
+      max-request-size: 5MB
   jackson:
     serialization:
       fail-on-empty-beans: false
@@ -46,3 +50,14 @@ tossPayments:
   clientKey: ${tossPayments.apiClientKey}
   secretKey: ${tossPayments.apiSecretKey}
   url: "https://api.tosspayments.com/v1/payments/"
+cloud:
+  aws:
+    credentials:
+      accessKey: ${cloud.aws.credentials.accessKey}
+      secretKey: ${cloud.aws.credentials.secretKey}
+    s3:
+      bucketName: ${cloud.aws.s3.bucketName}
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false


### PR DESCRIPTION
## 작업내용 

### S3 설정, 구현
- S3 의존성 추가
- 파일 업로드 관련 설정 (서블릿 구성) 
  - 업로드 파일의 최대 크기를 5MB로 제한
- S3 Config 설정 
  - AWS key 및 region을 사용하여 S3 클라이언트 빌드
- S3를 이용한 이미지 업로드 및 삭제 서비스 클래스 추가 
  - upload 메서드: 전달된 MultipartFile 객체를 기반으로 이미지를 S3에 업로드하고 업로드된 이미지의 공개 URL 반환
  - deleteImageFromS3: 이미지의 공개 URL을 받아 해당 이미지를 S3에서 삭제

<br/> 
 
### 프로필 이미지 업로드, 불러오기 관련 기능
-  프로필 이미지 등록 기능 추가 
   - 프로필 이미지 url 관련 member, memberDto 클래스 수정
   - 프로필 이미지 변경(등록), 프로필 이미지 URL 불러오기 API 추가
   - 프로필 이미지를 변경하면 기존의 이미지는 S3에서 삭제되도록 설정
   - 모달로 미리보기 기능 추가
   - rq의 member 정보에 profileImageUrl 관련 코드 추가

<br/>

- 공고번호로 작성자의 프로필 이미지 URL 불러오기, 아이디로 프로필 이미지 URL 불러오기 API 추가 
  - SecurityConfig 에서 프로필 이미지 URL 불러오기 관련 엔드포인트들을 permitAll() 설정
  
- 공고 상세페이지에서 작성자의 프로필 이미지가 보이도록 설정
- 공고 상세페이지의 댓글 목록에서 프로필 이미지가 보이도록 설정

- daisyui의 primary 색상 변경 (기본 보라색에서 초록색으로 변경)
