### PR TITLE
refactor: 카테고리 리팩토링

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -9,7 +9,7 @@ on:
       - README.md
       - back/infraScript/**
     branches:
-      - feature/refactoring-category
+      - dev
 
 permissions:
   contents: write
@@ -90,6 +90,6 @@ jobs:
           comment: AWS Zero Downtime Deployment
           command: |
             mkdir -p /docker_projects/goohaeyou
-            curl -o /docker_projects/goohaeyou/zero_downtime_deploy.py https://raw.githubusercontent.com/feature/refactoring-category/infraScript/zero_downtime_deploy.py
+            curl -o /docker_projects/goohaeyou/zero_downtime_deploy.py https://raw.githubusercontent.com/dev/back/infraScript/zero_downtime_deploy.py
             chmod +x /docker_projects/goohaeyou/zero_downtime_deploy.py
             /docker_projects/goohaeyou/zero_downtime_deploy.py

--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -9,7 +9,7 @@ on:
       - README.md
       - back/infraScript/**
     branches:
-      - dev
+      - feature/refactoring-category
 
 permissions:
   contents: write
@@ -90,6 +90,6 @@ jobs:
           comment: AWS Zero Downtime Deployment
           command: |
             mkdir -p /docker_projects/goohaeyou
-            curl -o /docker_projects/goohaeyou/zero_downtime_deploy.py https://raw.githubusercontent.com/dev/feature/refactor-structure/infraScript/zero_downtime_deploy.py
+            curl -o /docker_projects/goohaeyou/zero_downtime_deploy.py https://raw.githubusercontent.com/feature/refactoring-category/infraScript/zero_downtime_deploy.py
             chmod +x /docker_projects/goohaeyou/zero_downtime_deploy.py
             /docker_projects/goohaeyou/zero_downtime_deploy.py

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 <br/>
 
-<p align="center">
-  <img src="https://github.com/Techit7-11/GooHaeYou/assets/76129297/0d344997-8b50-4120-b493-62acd810ae54" width="300px"/><br><br>
+<p align="center"
+  <img src="https://github.com/user-attachments/assets/ed6b02b9-88ac-47dd-9f41-d52170425b0c" width="250px"/><br><br>
   <a href="https://www.goohaeyou.site/">사이트 바로가기</a>
   <br/>혹은 <a href="https://www.google.com/search?q=%EA%B5%AC%ED%95%B4%EC%9C%A0">Google에 '구해유' 검색</a>
+  <br/>(PC/모바일 겸용)<br/>
 </p>
 
 <br/><br/>
@@ -28,13 +29,13 @@
 - 프로젝트 주제 : 스팟 채용 서비스
 - 주요 기능 :
     - 로그인, 로그아웃, 회원가입, 마이페이지
-    - 구인 공고, 댓글 작성, 수정, 삭제
+    - 구인 공고 CRUD, 댓글 CRUD
     - 구인 공고 검색, 정렬, 필터
     - 1:1 채팅
     - 결제, 정산
     - 알림, 웹 푸시
     - 지도
-    - 이미지 업로드
+    - 카테고리, 이미지 업로드
 
 <br/>
 
@@ -45,7 +46,7 @@
 |:-----------------------------------------------------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------------------------------------:|
 | <img src="https://github.com/Techit7-11/GooHaeYou/assets/76129297/e5cb563e-a100-437e-aa7f-bc6ec1bd7456" width=120px alt="민구"> | <img src="https://github.com/Techit7-11/GooHaeYou/assets/76129297/2bf3093d-03b6-4b4e-9bcf-3e39ce9ec4e9" width=120px alt="재열"> | <img src="https://github.com/Techit7-11/GooHaeYou/assets/76129297/374149e6-d9d1-4598-88d4-724b81dca29d" width=120px alt="재준"> | <img src="https://github.com/Techit7-11/GooHaeYou/assets/76129297/8137422f-dd32-4de6-875c-9abbef5c9683" width=120px alt="지은"> | <img src="https://github.com/Techit7-11/GooHaeYou/assets/76129297/8c104315-4f51-45ec-804d-154d65da47cf" width=120px alt="세희"> | 
 |                                              [Yimin2](https://github.com/Yimin2)                                              |                                             [jae9380](https://github.com/jae9380)                                             |                                             [lapishi](https://github.com/lapishi)                                             |                                              [itonse](https://github.com/itonse)                                              |                                            [sehee210](https://github.com/sehee210)                                            |             
-|                                 로그 인/아웃<br/>회원가입<br/>JWT token, 쿠키<br/>Oauth 2.0 인증<br/>리뷰, 댓글 CRUD                                  |                             공고, 댓글, 추천<br/> 알림 시스템<br/> 공고 자동 마감<br/> 자동 알바 완료<br/>1:1채팅<br/>FCM(웹 푸시)                              |                                                  공고/댓글 삭제<br/>검색, 회원 레벨                                                   |            CI/CD, 배포<br/>결제, DB 관리<br/>공고, 프로필 이미지 CRUD<br/>카테고리<br/>급여 설정<br>수동 알바완료<br/>알바 취소 처리<br/>e-mail 본인인증            | 검색 & 필터<br/>공고 정렬<br>공고 지원하기<br/>작성글 모아보기<br/>마이페이지, 지도
+|                                 로그 인/아웃<br/>회원가입<br/>JWT token, 쿠키<br/>Oauth 2.0 인증<br/>리뷰, 댓글 CRUD                                  |                             공고, 댓글, 추천<br/> 알림 시스템<br/> 공고 자동 마감<br/> 자동 알바 완료<br/>1:1채팅<br/>FCM(웹 푸시)                              |                                                  공고/댓글 삭제<br/>검색, 회원 레벨                                                   |                 인프라, DB 관리<br/>결제, 카테고리<br/>공고, 프로필 이미지 설정<br/>급여 설정<br>수동 알바완료<br/>알바 취소 처리<br/>e-mail 본인인증                  | 검색 & 필터<br/>공고 정렬<br>공고 지원하기<br/>작성글 모아보기<br/>마이페이지, 지도
 |                         [commit](https://github.com/Techit7-11/GooHaeYou/commits/dev/?author=Yimin2)                          |                         [commit](https://github.com/Techit7-11/GooHaeYou/commits/dev/?author=jae9380)                         |                         [commit](https://github.com/Techit7-11/GooHaeYou/commits/dev/?author=lapishi)                         |                         [commit](https://github.com/Techit7-11/GooHaeYou/commits/dev/?author=itonse)                          |                        [commit](https://github.com/Techit7-11/GooHaeYou/commits/dev/?author=sehee210)                         |
 
 <br/><br/>
@@ -53,17 +54,17 @@
 ## 📱 구해유 기능 영상
 
 
-| 지도 기능 📍                                                                                                                 | 공고에 지원하기 기능 ✏️                                                                                                           |
+| 지도 기능 📍                                                                                                               | 공고에 지원하기 기능 ✏️                                                                                                         |
 |------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------|
-| <img src="https://github.com/Techit7-11/GooHaeYou/assets/76129297/278502cd-f1f2-4835-926d-ef77a1bc399f" width="300px"> | <img src="https://github.com/Techit7-11/GooHaeYou/assets/76129297/b147bd89-d873-4196-a9b1-b8769ae27fe9" width="300px"> |
+| <img src="https://github.com/Techit7-11/GooHaeYou/assets/76129297/278502cd-f1f2-4835-926d-ef77a1bc399f" width="280px"> | <img src="https://github.com/Techit7-11/GooHaeYou/assets/76129297/b147bd89-d873-4196-a9b1-b8769ae27fe9" width="280px"> |
 
-| 지원서 승인 기능 ✅                                                                                                             | 알바비 결제 기능 💸                                                                                                              |
+| 지원서 승인 기능 ✅                                                                                                            | 알바비 결제 기능 💸                                                                                                           |
 |------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------|
-| <img src="https://github.com/Techit7-11/GooHaeYou/assets/76129297/d52edb01-05e5-4aae-8362-94634c936a41" width="300px"> | <img src="https://github.com/Techit7-11/GooHaeYou/assets/76129297/a6ba5065-54db-448f-ae99-fb2ef197c6dc" width="300px"> |
+| <img src="https://github.com/Techit7-11/GooHaeYou/assets/76129297/d52edb01-05e5-4aae-8362-94634c936a41" width="280px"> | <img src="https://github.com/Techit7-11/GooHaeYou/assets/76129297/a6ba5065-54db-448f-ae99-fb2ef197c6dc" width="280px"> |
 
-| 이메일 본인인증 기능 📧                                                                                                        |
-|-----------------------------------------------------------------------------------------------------------------------|
-| <img src="https://github.com/Techit7-11/GooHaeYou/assets/76129297/2548bf24-eaf6-4192-b5fd-b5adf43d37ca" width="300px"> |
+| 이메일 본인인증 기능 📧                                                                                                         |
+|------------------------------------------------------------------------------------------------------------------------|
+| <img src="https://github.com/Techit7-11/GooHaeYou/assets/76129297/2548bf24-eaf6-4192-b5fd-b5adf43d37ca" width="280px"> |
 
 <br/><br/>
 
@@ -72,24 +73,20 @@
 
 <br/>
 
-| <h3>백엔드</h3>                                                                                        |
-|-----------------------------------------------------------------------------------------------------|
-| <img src="https://github.com/Techit7-11/GooHaeYou/assets/76129297/5cc54e75-51c5-458b-a79e-e95369dc9401" width=700px alt="백엔드"> |
-
-| <h3>인프라</h3>                                                                                                                   |
+| <h3>백엔드</h3>                                                                                                                   |
 |--------------------------------------------------------------------------------------------------------------------------------|
-| <img src="https://github.com/Techit7-11/GooHaeYou/assets/76129297/9976ae98-b37a-4668-b9c0-4af008c47e5a" width=550px alt="인프라"> |
+| <img src="https://github.com/Techit7-11/GooHaeYou/assets/76129297/5cc54e75-51c5-458b-a79e-e95369dc9401" width=580px alt="백엔드"> |
 
-| <h3>프론트엔드</h3>                                                                                                                   |
-|----------------------------------------------------------------------------------------------------------------------------------|
-| <img src="https://github.com/Techit7-11/GooHaeYou/assets/76129297/81da74fe-b688-4a11-a9e7-e17f644902d5" width=420px alt="프론트엔드"> |
+| <h3>인프라</h3>                                                                                                                   | <h3>프론트엔드</h3>                                                                                                                   |
+|--------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|
+| <img src="https://github.com/Techit7-11/GooHaeYou/assets/76129297/9976ae98-b37a-4668-b9c0-4af008c47e5a" width=450px alt="인프라"> | <img src="https://github.com/Techit7-11/GooHaeYou/assets/76129297/81da74fe-b688-4a11-a9e7-e17f644902d5" width=340px alt="프론트엔드"> |
 
-| <h3>외부 API</h3>                                                                                      | <h3>협업</h3>                                                                                             |
-|------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------|
-| <img src="https://github.com/Techit7-11/GooHaeYou/assets/76129297/3b52aa7a-02c5-43e3-a5ac-a57b4201cf5e" width=300px alt="외부API"> | <img src="https://github.com/Techit7-11/GooHaeYou/assets/76129297/7747ea25-e9e0-4f64-9b53-f8e6fa847bf0" width=400px alt="협업"> |
+| <h3>외부 API</h3>                                                                                                                  | <h3>협업</h3>                                                                                                                   |
+|----------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------|
+| <img src="https://github.com/Techit7-11/GooHaeYou/assets/76129297/3b52aa7a-02c5-43e3-a5ac-a57b4201cf5e" width=250px alt="외부API"> | <img src="https://github.com/Techit7-11/GooHaeYou/assets/76129297/7747ea25-e9e0-4f64-9b53-f8e6fa847bf0" width=340px alt="협업"> |
 
 <br/>
 
 ## 📝 ERD
 
-![goohaeyou](https://github.com/Techit7-11/goohaeyou/assets/76129297/78d995fa-0ffd-48df-a762-c56ba8458537)
+![erd_0726](https://github.com/user-attachments/assets/dc22116b-25da-4663-b06c-90fb6d12c6af)

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@
 <p align="center"
   <img src="https://github.com/user-attachments/assets/ed6b02b9-88ac-47dd-9f41-d52170425b0c" width="250px"/><br><br>
   <a href="https://www.goohaeyou.site/">사이트 바로가기</a>
-  <br/>혹은 <a href="https://www.google.com/search?q=%EA%B5%AC%ED%95%B4%EC%9C%A0">Google에 '구해유' 검색</a>
-  <br/>(PC/모바일 겸용)<br/>
+  <br/>PC/모바일 겸용<br/>
 </p>
 
 <br/><br/>

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 <br/>
 
-<p align="center"
-  <img src="https://github.com/user-attachments/assets/ed6b02b9-88ac-47dd-9f41-d52170425b0c" width="250px"/><br><br>
+<p align="center">
+  <img src="https://github.com/user-attachments/assets/a754ade8-e469-4533-8cd9-a08e806d1521" width="700px"/><br/><br/><br/>
   <a href="https://www.goohaeyou.site/">사이트 바로가기</a>
   <br/>PC/모바일 겸용<br/>
 </p>
@@ -88,4 +88,4 @@
 
 ## 📝 ERD
 
-![erd_0726](https://github.com/user-attachments/assets/dc22116b-25da-4663-b06c-90fb6d12c6af)
+![erd_0727](https://github.com/user-attachments/assets/4dee13ce-97aa-4448-a26f-874f509a18dd)

--- a/back/build.gradle
+++ b/back/build.gradle
@@ -99,6 +99,9 @@ dependencies {
 
 	// S3
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+	// Slack
+	implementation 'com.slack.api:slack-api-client:1.40.2'
 }
 
 // 테스트를 실행할때마다 jacoco 리포트 생성

--- a/back/src/main/java/com/ll/goohaeyou/domain/category/dto/CategoryDto.java
+++ b/back/src/main/java/com/ll/goohaeyou/domain/category/dto/CategoryDto.java
@@ -11,7 +11,6 @@ import java.util.List;
 public class CategoryDto {
     private Long id;
     private String name;
-    private int code;
     private int level;
     private Long parentId;
 
@@ -19,7 +18,6 @@ public class CategoryDto {
         return CategoryDto.builder()
                 .id(category.getId())
                 .name(category.getName())
-                .code(category.getCode())
                 .level(category.getLevel())
                 .parentId(category.getParent() != null ? category.getParent().getId() : null)
                 .build();

--- a/back/src/main/java/com/ll/goohaeyou/domain/category/dto/CategoryForm.java
+++ b/back/src/main/java/com/ll/goohaeyou/domain/category/dto/CategoryForm.java
@@ -1,5 +1,6 @@
 package com.ll.goohaeyou.domain.category.dto;
 
+import com.ll.goohaeyou.domain.category.entity.type.CategoryType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
@@ -16,6 +17,7 @@ public class CategoryForm {
         @NotNull
         private int level = 0;
 
+        private CategoryType type;
         private boolean enabled = true;
     }
 }

--- a/back/src/main/java/com/ll/goohaeyou/domain/category/dto/CategoryForm.java
+++ b/back/src/main/java/com/ll/goohaeyou/domain/category/dto/CategoryForm.java
@@ -14,8 +14,6 @@ public class CategoryForm {
         @NotBlank
         private String name;
         @NotNull
-        private int code = 0;
-        @NotNull
         private int level = 0;
 
         private boolean enabled = true;

--- a/back/src/main/java/com/ll/goohaeyou/domain/category/entity/Category.java
+++ b/back/src/main/java/com/ll/goohaeyou/domain/category/entity/Category.java
@@ -1,5 +1,6 @@
 package com.ll.goohaeyou.domain.category.entity;
 
+import com.ll.goohaeyou.domain.category.entity.type.CategoryType;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -25,6 +26,9 @@ public class Category {
     private int level = 0;
 
     private boolean enabled = true;
+
+    @Enumerated(EnumType.STRING)
+    private CategoryType type;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_id")

--- a/back/src/main/java/com/ll/goohaeyou/domain/category/entity/Category.java
+++ b/back/src/main/java/com/ll/goohaeyou/domain/category/entity/Category.java
@@ -1,10 +1,7 @@
 package com.ll.goohaeyou.domain.category.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,9 +20,6 @@ public class Category {
 
     @Column(unique = true, nullable = false)
     private String name;
-
-    @Column(nullable = false)
-    private int code = 0;
 
     @Column(nullable = false)
     private int level = 0;

--- a/back/src/main/java/com/ll/goohaeyou/domain/category/entity/JobPostCategory.java
+++ b/back/src/main/java/com/ll/goohaeyou/domain/category/entity/JobPostCategory.java
@@ -1,0 +1,26 @@
+package com.ll.goohaeyou.domain.category.entity;
+
+import com.ll.goohaeyou.domain.jobPost.jobPost.entity.JobPost;
+import jakarta.persistence.*;
+import lombok.*;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@AllArgsConstructor(access = PROTECTED)
+@NoArgsConstructor(access = PROTECTED)
+@Builder
+@Getter
+public class JobPostCategory {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
+
+    @ManyToOne
+    @JoinColumn(name = "job_post_id", nullable = false)
+    private JobPost jobPost;
+}

--- a/back/src/main/java/com/ll/goohaeyou/domain/category/entity/JobPostCategory.java
+++ b/back/src/main/java/com/ll/goohaeyou/domain/category/entity/JobPostCategory.java
@@ -23,4 +23,8 @@ public class JobPostCategory {
     @ManyToOne
     @JoinColumn(name = "job_post_id", nullable = false)
     private JobPost jobPost;
+
+    public void updateCategory(Category category) {
+        this.category = category;
+    }
 }

--- a/back/src/main/java/com/ll/goohaeyou/domain/category/entity/repository/JobPostCategoryRepository.java
+++ b/back/src/main/java/com/ll/goohaeyou/domain/category/entity/repository/JobPostCategoryRepository.java
@@ -1,0 +1,9 @@
+package com.ll.goohaeyou.domain.category.entity.repository;
+
+import com.ll.goohaeyou.domain.category.entity.JobPostCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface JobPostCategoryRepository extends JpaRepository<JobPostCategory, Long> {
+}

--- a/back/src/main/java/com/ll/goohaeyou/domain/category/entity/repository/JobPostCategoryRepository.java
+++ b/back/src/main/java/com/ll/goohaeyou/domain/category/entity/repository/JobPostCategoryRepository.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface JobPostCategoryRepository extends JpaRepository<JobPostCategory, Long> {
-    @Query("SELECT jpc.jobPost FROM JobPostCategory jpc WHERE jpc.category.id = :categoryId")
+    @Query("SELECT jpc.jobPost FROM JobPostCategory jpc WHERE jpc.category.id = :categoryId ORDER BY jpc.jobPost.createdAt DESC")
     Page<JobPost> findJobPostsByCategoryId(@Param("categoryId") Long categoryId, Pageable pageable);
 
     void deleteAllByJobPost(JobPost jobPost);

--- a/back/src/main/java/com/ll/goohaeyou/domain/category/entity/repository/JobPostCategoryRepository.java
+++ b/back/src/main/java/com/ll/goohaeyou/domain/category/entity/repository/JobPostCategoryRepository.java
@@ -1,6 +1,7 @@
 package com.ll.goohaeyou.domain.category.entity.repository;
 
 import com.ll.goohaeyou.domain.category.entity.JobPostCategory;
+import com.ll.goohaeyou.domain.category.entity.type.CategoryType;
 import com.ll.goohaeyou.domain.jobPost.jobPost.entity.JobPost;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -15,4 +16,6 @@ public interface JobPostCategoryRepository extends JpaRepository<JobPostCategory
     Page<JobPost> findJobPostsByCategoryId(@Param("categoryId") Long categoryId, Pageable pageable);
 
     void deleteAllByJobPost(JobPost jobPost);
+
+    JobPostCategory findByJobPostAndCategory_Type(JobPost jobPost, CategoryType categoryType);
 }

--- a/back/src/main/java/com/ll/goohaeyou/domain/category/entity/repository/JobPostCategoryRepository.java
+++ b/back/src/main/java/com/ll/goohaeyou/domain/category/entity/repository/JobPostCategoryRepository.java
@@ -2,10 +2,17 @@ package com.ll.goohaeyou.domain.category.entity.repository;
 
 import com.ll.goohaeyou.domain.category.entity.JobPostCategory;
 import com.ll.goohaeyou.domain.jobPost.jobPost.entity.JobPost;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface JobPostCategoryRepository extends JpaRepository<JobPostCategory, Long> {
+    @Query("SELECT jpc.jobPost FROM JobPostCategory jpc WHERE jpc.category.id = :categoryId")
+    Page<JobPost> findJobPostsByCategoryId(@Param("categoryId") Long categoryId, Pageable pageable);
+
     void deleteAllByJobPost(JobPost jobPost);
 }

--- a/back/src/main/java/com/ll/goohaeyou/domain/category/entity/repository/JobPostCategoryRepository.java
+++ b/back/src/main/java/com/ll/goohaeyou/domain/category/entity/repository/JobPostCategoryRepository.java
@@ -1,9 +1,11 @@
 package com.ll.goohaeyou.domain.category.entity.repository;
 
 import com.ll.goohaeyou.domain.category.entity.JobPostCategory;
+import com.ll.goohaeyou.domain.jobPost.jobPost.entity.JobPost;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface JobPostCategoryRepository extends JpaRepository<JobPostCategory, Long> {
+    void deleteAllByJobPost(JobPost jobPost);
 }

--- a/back/src/main/java/com/ll/goohaeyou/domain/category/entity/type/CategoryType.java
+++ b/back/src/main/java/com/ll/goohaeyou/domain/category/entity/type/CategoryType.java
@@ -1,0 +1,6 @@
+package com.ll.goohaeyou.domain.category.entity.type;
+
+public enum CategoryType {
+    TASK,
+    REGION
+}

--- a/back/src/main/java/com/ll/goohaeyou/domain/category/service/CategoryAdminService.java
+++ b/back/src/main/java/com/ll/goohaeyou/domain/category/service/CategoryAdminService.java
@@ -34,6 +34,7 @@ public class CategoryAdminService {
                 .level(form.getLevel())
                 .enabled(form.isEnabled())
                 .parent(parent)
+                .type(form.getType())
                 .build();
 
         categoryRepository.save(newCategory);

--- a/back/src/main/java/com/ll/goohaeyou/domain/category/service/CategoryAdminService.java
+++ b/back/src/main/java/com/ll/goohaeyou/domain/category/service/CategoryAdminService.java
@@ -31,7 +31,6 @@ public class CategoryAdminService {
 
         Category newCategory = Category.builder()
                 .name(form.getName())
-                .code(form.getCode())
                 .level(form.getLevel())
                 .enabled(form.isEnabled())
                 .parent(parent)

--- a/back/src/main/java/com/ll/goohaeyou/domain/category/service/JobPostCategoryService.java
+++ b/back/src/main/java/com/ll/goohaeyou/domain/category/service/JobPostCategoryService.java
@@ -1,0 +1,22 @@
+package com.ll.goohaeyou.domain.category.service;
+
+import com.ll.goohaeyou.domain.category.entity.JobPostCategory;
+import com.ll.goohaeyou.domain.category.entity.repository.JobPostCategoryRepository;
+import com.ll.goohaeyou.domain.category.entity.type.CategoryType;
+import com.ll.goohaeyou.domain.jobPost.jobPost.entity.JobPost;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class JobPostCategoryService {
+    private final JobPostCategoryRepository jobPostCategoryRepository;
+
+    public JobPostCategory findByJobPostAndCategoryType(JobPost jobPost, CategoryType categoryType) {
+        return jobPostCategoryRepository.findByJobPostAndCategory_Type(jobPost, categoryType);
+    }
+}

--- a/back/src/main/java/com/ll/goohaeyou/domain/jobPost/jobPost/controller/JobPostController.java
+++ b/back/src/main/java/com/ll/goohaeyou/domain/jobPost/jobPost/controller/JobPostController.java
@@ -196,7 +196,12 @@ public class JobPostController {
 
     @GetMapping("/by-category")
     @Operation(summary = "카테고리의 글 목록 불러오기")
-    public ApiResponse<List<JobPostDto>> getPostsByCategory(@RequestParam("category_name") String categoryName) {
-        return ApiResponse.ok(jobPostService.getPostsByCategory(categoryName));
+    public ApiResponse<Page<JobPostDto>> getPostsByCategory(@RequestParam("category-name") String categoryName,
+                                                            @RequestParam(value = "page", defaultValue = "1") int page) {
+        Pageable pageable = PageRequest.of(page - 1, 10);
+
+        Page<JobPostDto> jobPostDtoPage = jobPostService.getPostsByCategory(categoryName, pageable);
+
+        return ApiResponse.ok(jobPostDtoPage);
     }
 }

--- a/back/src/main/java/com/ll/goohaeyou/domain/jobPost/jobPost/dto/JobPostForm.java
+++ b/back/src/main/java/com/ll/goohaeyou/domain/jobPost/jobPost/dto/JobPostForm.java
@@ -65,6 +65,8 @@ public class JobPostForm {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class Modify {
+        @NotNull(message = "카테고리 설정은 필수입니다.")
+        private Long categoryId;
 
         @NotBlank(message = "제목은 필수 입력 항목입니다.")
         private String title;

--- a/back/src/main/java/com/ll/goohaeyou/domain/jobPost/jobPost/entity/JobPost.java
+++ b/back/src/main/java/com/ll/goohaeyou/domain/jobPost/jobPost/entity/JobPost.java
@@ -55,13 +55,12 @@ public class JobPost extends BaseTimeEntity {
 
     private int regionCode;
 
-    public void update(String title, LocalDate deadline, LocalDate jobStartDate, int regionCode) {
+    public void update(String title, LocalDate deadline, LocalDate jobStartDate, String location, int regionCode) {
         if (title != null && !title.isBlank()) {
             this.title = title;
         }
-        if (regionCode != 0) {
-            this.regionCode = regionCode;
-        }
+        this.location = location;
+        this.regionCode = regionCode;
         this.deadline = deadline;
         this.jobStartDate = jobStartDate;
     }

--- a/back/src/main/java/com/ll/goohaeyou/domain/jobPost/jobPost/entity/JobPost.java
+++ b/back/src/main/java/com/ll/goohaeyou/domain/jobPost/jobPost/entity/JobPost.java
@@ -1,6 +1,5 @@
 package com.ll.goohaeyou.domain.jobPost.jobPost.entity;
 
-import com.ll.goohaeyou.domain.category.entity.Category;
 import com.ll.goohaeyou.domain.member.member.entity.Member;
 import com.ll.goohaeyou.global.jpa.BaseTimeEntity;
 import jakarta.persistence.*;
@@ -56,10 +55,6 @@ public class JobPost extends BaseTimeEntity {
 
     private int regionCode;
 
-    @ManyToOne
-    @JoinColumn(name = "category_id", nullable = false)
-    private Category category;
-
     public void update(String title, LocalDate deadline, LocalDate jobStartDate, int regionCode) {
         if (title != null && !title.isBlank()) {
             this.title = title;
@@ -71,7 +66,7 @@ public class JobPost extends BaseTimeEntity {
         this.jobStartDate = jobStartDate;
     }
 
-    public void SetDeadlineNull() {
+    public void setDeadlineNull() {
         this.deadline = null;
     }
 

--- a/back/src/main/java/com/ll/goohaeyou/domain/jobPost/jobPost/entity/repository/JobPostRepository.java
+++ b/back/src/main/java/com/ll/goohaeyou/domain/jobPost/jobPost/entity/repository/JobPostRepository.java
@@ -1,6 +1,5 @@
 package com.ll.goohaeyou.domain.jobPost.jobPost.entity.repository;
 
-import com.ll.goohaeyou.domain.category.entity.Category;
 import com.ll.goohaeyou.domain.jobPost.jobPost.entity.JobPost;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
@@ -14,9 +13,5 @@ public interface JobPostRepository extends JpaRepository<JobPost, Long>, JpaSpec
 
     List<JobPost> findByMemberId(Long id);
 
-    List<JobPost> findByClosedFalseAndDeadlineBefore(LocalDate currentDate); //    LocalDate
-
-    List<JobPost> findAllByCategoryOrderByCreatedAtDesc(Category category);
-
-    List<JobPost> findAllByRegionCodeOrderByCreatedAtDesc(int regionCode);
+    List<JobPost> findByClosedFalseAndDeadlineBefore(LocalDate currentDate);
 }

--- a/back/src/main/java/com/ll/goohaeyou/domain/jobPost/jobPost/service/JobPostService.java
+++ b/back/src/main/java/com/ll/goohaeyou/domain/jobPost/jobPost/service/JobPostService.java
@@ -63,7 +63,7 @@ public class JobPostService {
         int regionCode = Ut.Region.getRegionCodeFromAddress(form.getLocation());
         Category taskCategory = categoryRepository.findById(form.getCategoryId())
                 .orElseThrow(CategoryException.NotFoundCategoryException::new);
-        Category regionCategory = categoryRepository.findByName(RegionType.GetNameByCode(regionCode))
+        Category regionCategory = categoryRepository.findByName(RegionType.getNameByCode(regionCode))
                 .orElseThrow(CategoryException.NotFoundCategoryException::new);
 
         JobPost newPost = createAndSaveJobPost(username, form, regionCode);

--- a/back/src/main/java/com/ll/goohaeyou/domain/jobPost/jobPost/service/JobPostService.java
+++ b/back/src/main/java/com/ll/goohaeyou/domain/jobPost/jobPost/service/JobPostService.java
@@ -187,6 +187,7 @@ public class JobPostService {
                 s3ImageService.deletePostImagesFromS3(jobPostImages);
             }
 
+            jobPostCategoryRepository.deleteAllByJobPost(post);
             jobPostRepository.deleteById(postId);
         } else {
             throw new AuthException.NotAuthorizedException();

--- a/back/src/main/java/com/ll/goohaeyou/global/standard/base/RegionType.java
+++ b/back/src/main/java/com/ll/goohaeyou/global/standard/base/RegionType.java
@@ -36,4 +36,13 @@ public enum RegionType {
         }
         throw new CategoryException.NotFoundCategoryException();
     }
+
+    public static String GetNameByCode(int code) {
+        for (RegionType region : RegionType.values()) {
+            if (region.getCode() == code) {
+                return region.getName();
+            }
+        }
+        throw new CategoryException.NotFoundCategoryException();
+    }
 }

--- a/back/src/main/java/com/ll/goohaeyou/global/standard/base/RegionType.java
+++ b/back/src/main/java/com/ll/goohaeyou/global/standard/base/RegionType.java
@@ -37,7 +37,7 @@ public enum RegionType {
         throw new CategoryException.NotFoundCategoryException();
     }
 
-    public static String GetNameByCode(int code) {
+    public static String getNameByCode(int code) {
         for (RegionType region : RegionType.values()) {
             if (region.getCode() == code) {
                 return region.getName();

--- a/front/src/lib/components/CategoryPagination.svelte
+++ b/front/src/lib/components/CategoryPagination.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+	export let currentPage: number = 1;
+	export let totalPages: number = 1;
+	export let pageDelta: number = 1;
+	const dispatch = createEventDispatcher();
+
+	// 페이지네이션 범위 계산 함수
+	function calculatePaginationRange(current: number, total: number, delta = 4) {
+		const left = current - delta;
+		const right = current + delta;
+		const range = [] as { no: number; text: string }[];
+
+		if (total <= 1) return [];
+
+		for (let i = 1; i <= total; i++) {
+			if (i === 1) {
+				range.push({ no: i, text: `${i}` });
+			} else if (i == left - 1) {
+				range.push({ no: i, text: `...` });
+			} else if (i >= left && i <= right) {
+				range.push({ no: i, text: `${i}` });
+			} else if (i === total) {
+				range.push({ no: i, text: `${i}` });
+			} else if (i == right + 1) {
+				range.push({ no: i, text: `...` });
+			}
+		}
+		return range;
+	}
+</script>
+
+<div class="flex justify-center">
+	<div class="join">
+		{#each calculatePaginationRange(currentPage, totalPages, pageDelta) as pageNumber}
+			<button
+				class={`join-item btn ${pageNumber.no == currentPage ? 'text-green5' : ''}`}
+				on:click={() => dispatch('pageChange', pageNumber.no)}
+			>
+				{pageNumber.text}
+			</button>
+		{/each}
+	</div>
+</div>

--- a/front/src/lib/components/Pagination.svelte
+++ b/front/src/lib/components/Pagination.svelte
@@ -33,7 +33,7 @@
 	<div class="join">
 		{#each calculatePaginationRange(page.number, page.totalPagesCount, pageDelta) as pageNumber}
 			<button
-				class={`join-item btn ${pageNumber.no == page.number ? 'text-red-300' : ''}`}
+				class={`join-item btn ${pageNumber.no == page.number ? 'text-green5' : ''}`}
 				on:click={() => rq.goToCurrentPageWithNewParam('page', `${pageNumber.no}`)}
 			>
 				{pageNumber.text}

--- a/front/src/routes/+page.svelte
+++ b/front/src/routes/+page.svelte
@@ -84,7 +84,7 @@
 	<div class="flex justify-center min-h-screen bg-base-100">
 		<div class="container mx-auto px-4">
 			<div class="w-full max-w-4xl mx-auto">
-				<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+				<div class="grid grid-cols-1 md:grid-cols-2 gap-3">
 					{#each posts ?? [] as post, index}
 						<a href="/job-post/{post.id}" class="block">
 							<div class="card relative bg-base-100 shadow-xl my-4">
@@ -108,16 +108,57 @@
 									</div>
 								</div>
 								<div class="card-body pt-1">
-									<div class="flex items-center justify-between">
-										<div class="flex items-center">
-											<!-- 메인 이미지가 존재하는 경우 -->
-											{#if post.mainImageUrl}
+									<!-- 메인 이미지가 존재하는 경우 -->
+									{#if post.mainImageUrl}
+										<div class="flex">
+											<div class="flex flex-col">
 												<img
 													src={post.mainImageUrl}
 													alt={post.title}
-													class="mr-4 w-20 h-20 object-cover"
+													class="w-20 h-20 object-cover mb-1"
 												/>
-											{/if}
+												<div class="flex mb-2">
+													<div class="flex flex-col items-center mr-2">
+														<div class="text-xs mx-2 flex justify-center items-center">
+															{post.incrementViewCount}
+														</div>
+														<div class="text-xs text-gray-500">봤어유</div>
+													</div>
+													<div class="flex flex-col items-center mr-2">
+														<div class="text-xs mx-2 flex justify-center items-center">
+															{post.commentsCount}
+														</div>
+														<div class="text-xs text-gray-500">쑥덕쑥덕</div>
+													</div>
+													<div class="flex flex-col items-center">
+														<div class="text-xs mx-2 flex justify-center items-center">
+															{post.interestsCount}
+														</div>
+														<div class="text-xs text-gray-500">관심있슈</div>
+													</div>
+												</div>
+											</div>
+											<div class="flex flex-col flex-1">
+												<div class="text-xl font-bold line-clamp-2">
+													{post.title}
+												</div>
+												<div class="flex items-center justify-between mt-2">
+													<div class="flex flex-col items-center flex-nowrap ml-auto">
+														{#if post.closed}
+															<div class="badge badge-neutral whitespace-nowrap">구했어유</div>
+														{:else}
+															<div class="badge badge-primary my-1 whitespace-nowrap">구해유</div>
+															<div class="text-xs text-gray-500 whitespace-nowrap">
+																~ {post.deadLine}
+															</div>
+														{/if}
+													</div>
+												</div>
+											</div>
+										</div>
+									{:else}
+										<!-- 메인 이미지가 존재하지 않는 경우 -->
+										<div class="flex items-center justify-between">
 											<div
 												class="flex flex-col max-40 sm:max-w-sm md:max-w-md lg:max-w-lg xl:max-w-xl overflow-hidden"
 											>
@@ -145,20 +186,20 @@
 													</div>
 												</div>
 											</div>
-										</div>
-										<div class="flex items-center justify-between min-w-[77px] ml-4">
-											<div class="flex flex-col items-center flex-nowrap">
-												{#if post.closed}
-													<div class="badge badge-neutral whitespace-nowrap">구했어유</div>
-												{:else}
-													<div class="badge badge-primary my-1 whitespace-nowrap">구해유</div>
-													<div class="text-xs text-gray-500 whitespace-nowrap">
-														~ {post.deadLine}
-													</div>
-												{/if}
+											<div class="flex items-center justify-between min-w-[77px] ml-4">
+												<div class="flex flex-col items-center flex-nowrap">
+													{#if post.closed}
+														<div class="badge badge-neutral whitespace-nowrap">구했어유</div>
+													{:else}
+														<div class="badge badge-primary my-1 whitespace-nowrap">구해유</div>
+														<div class="text-xs text-gray-500 whitespace-nowrap">
+															~ {post.deadLine}
+														</div>
+													{/if}
+												</div>
 											</div>
 										</div>
-									</div>
+									{/if}
 								</div>
 							</div>
 						</a>

--- a/front/src/routes/categories/+page.svelte
+++ b/front/src/routes/categories/+page.svelte
@@ -1,14 +1,18 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import rq from '$lib/rq/rq.svelte';
+	import { page } from '$app/stores';
 	import type { components } from '$lib/types/api/v1/schema';
+	import Pagination from '$lib/components/CategoryPagination.svelte';
 
 	let categories: components['schemas']['CategoryDto'][] = [];
 	let subCategories: components['schemas']['CategoryDto'][] = [];
-	let posts: components['schemas']['JobPostDto'][] = [];
+	let posts: any = null;
 	let selectedCategoryName = '';
 	let isLeafCategory = false;
 	let error = '';
+	let currentPage = 1;
+	let totalPages = 1;
 
 	async function loadCategories() {
 		try {
@@ -35,14 +39,22 @@
 		}
 	}
 
-	async function loadPosts(categoryName: string) {
-		try {
-			const params = new URLSearchParams({ category_name: categoryName });
-			const { data } = await rq.apiEndPoints().GET(`/api/job-posts/by-category?${params}`);
-			posts = data?.data ?? [];
-		} catch (e) {
-			console.error('Error loading posts:', e);
-			error = '글 목록을 로드하는 중 오류가 발생했습니다.';
+	async function loadPosts(categoryName: string, page: number = 1) {
+		const params = new URLSearchParams({
+			'category-name': categoryName,
+			page: String(page)
+		});
+
+		const response = await rq.apiEndPoints().GET(`/api/job-posts/by-category?${params}`);
+
+		if (response.data?.resultType === 'SUCCESS') {
+			posts = response.data.data ?? [];
+			currentPage = posts.number + 1;
+			totalPages = posts.totalPages;
+		} else if (response.data?.resultType === 'CUSTOM_EXCEPTION') {
+			rq.msgError(response.data?.message);
+		} else {
+			rq.msgError('글 목록을 로드하는 중 오류가 발생했습니다.');
 		}
 	}
 
@@ -52,6 +64,11 @@
 		if (isLeafCategory) {
 			await loadPosts(category.name);
 		}
+	}
+
+	function handlePageChange(event) {
+		const newPage = event.detail;
+		loadPosts(selectedCategoryName, newPage);
 	}
 
 	async function initialize() {
@@ -76,132 +93,192 @@
 	<title>구해유 - 카테고리</title>
 </svelte:head>
 
-{#await initialize()}
-	<div class="flex items-center justify-center min-h-screen">
-		<span class="loading loading-dots loading-lg"></span>
-	</div>
-{:then}
-	<div class="flex flex-col items-center p-4 space-y-4">
-		<div class="menu bg-base-200 w-full rounded-box p-4 shadow-lg">
-			{#if categories.length > 0}
-				{#each categories as category}
-					<details class="mb-2">
-						<summary
-							on:click={() => handleCategoryClick(category)}
-							class="cursor-pointer bg-primary text-white rounded-md p-2"
-						>
-							{category.name}
-						</summary>
-						{#if subCategories.length > 0 && selectedCategoryName === category.name}
-							<ul class="list-disc list-inside pl-4 space-y-2 mt-2">
-								{#each subCategories as subCategory}
-									<li>
-										<a
-											href="#"
-											on:click|preventDefault={() => handleCategoryClick(subCategory)}
-											class="text-gray-900 hover:underline"
-										>
-											{subCategory.name}
-										</a>
-									</li>
-								{/each}
-							</ul>
-						{/if}
-					</details>
-				{/each}
-			{:else}
-				<p class="text-center p-4 text-red-500">카테고리가 없습니다.</p>
-			{/if}
-		</div>
-
-		<div class="w-full p-4 max-w-4xl mx-auto">
-			{#if error}
-				<p class="text-red-500">{error}</p>
-			{:else if isLeafCategory && posts.length === 0}
-				<p class="text-center p-4 text-500">해당 카테고리에 글이 없습니다.</p>
-			{:else if posts.length > 0}
-				<h2 class="text-2xl font-bold mb-4">{selectedCategoryName}</h2>
-				<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-					{#each posts as post}
-						<a href="/job-post/{post.id}" class="block">
-							<div class="card relative bg-base-100 shadow-xl my-4">
-								<div class="card-body flex flex-row justify-between">
-									<div>
-										<div class="text-bold text-gray-500 mb-1">{post.author}</div>
-										<div class="text-xs text-gray-500">{post.location}</div>
-									</div>
-									<div class="flex justify-center items-center">
-										<svg
-											xmlns="http://www.w3.org/2000/svg"
-											id="Outline"
-											viewBox="0 0 24 24"
-											width="12"
-											height="12"
-										>
-											<path
-												d="M7,24a1,1,0,0,1-.71-.29,1,1,0,0,1,0-1.42l8.17-8.17a3,3,0,0,0,0-4.24L6.29,1.71A1,1,0,0,1,7.71.29l8.17,8.17a5,5,0,0,1,0,7.08L7.71,23.71A1,1,0,0,1,7,24Z"
-											/>
-										</svg>
-									</div>
-								</div>
-								<div class="card-body pt-1">
-									<div class="flex items-center justify-between">
-										<div class="flex items-center">
-											{#if post.mainImageUrl}
-												<img
-													src={post.mainImageUrl}
-													alt={post.title}
-													class="mr-4 w-20 h-20 object-cover"
-												/>
-											{/if}
-											<div
-												class="flex flex-col max-40 sm:max-w-sm md:max-w-md lg:max-w-lg xl:max-w-xl overflow-hidden"
+<div class="flex items-center justify-center min-h-screen">
+	{#if error}
+		<p class="text-red-500">{error}</p>
+	{:else}
+		<div class="flex flex-col items-center p-4 space-y-4">
+			<div class="menu bg-base-200 w-full rounded-box p-4 shadow-lg">
+				{#if categories.length > 0}
+					{#each categories as category}
+						<details class="mb-2">
+							<summary
+								on:click={() => handleCategoryClick(category)}
+								class="cursor-pointer bg-primary text-white rounded-md p-2"
+							>
+								{category.name}
+							</summary>
+							{#if subCategories.length > 0 && selectedCategoryName === category.name}
+								<ul class="list-disc list-inside pl-4 space-y-2 mt-2">
+									{#each subCategories as subCategory}
+										<li>
+											<a
+												href="#"
+												on:click|preventDefault={() => handleCategoryClick(subCategory)}
+												class="text-gray-900 hover:underline"
 											>
-												<div class="text-xl font-bold max-w-full line-clamp-2">{post.title}</div>
-												<div class="flex mt-2">
-													<div class="flex-shrink">
-														<div class="text-xs mx-2 flex justify-center items-center">
-															{post.incrementViewCount}
-														</div>
-														<div class="text-xs text-gray-500">봤어유</div>
-													</div>
-													<div class="flex-shrink ml-3">
-														<div class="text-xs mx-2 flex justify-center items-center">
-															{post.commentsCount}
-														</div>
-														<div class="text-xs text-gray-500">쑥덕쑥덕</div>
-													</div>
-													<div class="flex-shrink ml-3">
-														<div class="text-xs mx-2 flex justify-center items-center">
-															{post.interestsCount}
-														</div>
-														<div class="text-xs text-gray-500">관심있슈</div>
-													</div>
+												{subCategory.name}
+											</a>
+										</li>
+									{/each}
+								</ul>
+							{/if}
+						</details>
+					{/each}
+				{:else}
+					<p class="text-center p-4 text-red-500">카테고리가 없습니다.</p>
+				{/if}
+			</div>
+
+			<!-- 글 목록이 나타나는 부분 -->
+			<div class="flex justify-center min-h-screen bg-base-100 w-full">
+				<div class="container mx-auto px-4">
+					<!-- 글 목록의 너비 설정 -->
+					<div class="w-full max-w-4xl mx-auto">
+						{#if posts === null}
+							<p>카테고리를 선택해주세요</p>
+						{:else if isLeafCategory && posts?.content?.length === 0}
+							<p class="text-center p-4 text-500">해당 카테고리에 글이 없습니다.</p>
+						{:else if posts?.content?.length > 0}
+							<h2 class="text-lg font-bold mb-4">카테고리 > {selectedCategoryName}</h2>
+							<!-- 글 목록을 그리드 레이아웃으로 배치 -->
+							<div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+								{#each posts.content as post}
+									<a href="/job-post/{post.id}" class="block">
+										<div class="card relative bg-base-100 shadow-xl my-4">
+											<div class="card-body flex flex-row justify-between">
+												<div>
+													<div class="text-bold text-gray-500 mb-1">{post.author}</div>
+													<div class="text-xs text-gray-500">{post.location}</div>
+												</div>
+												<div class="flex justify-center items-center">
+													<svg
+														xmlns="http://www.w3.org/2000/svg"
+														id="Outline"
+														viewBox="0 0 24 24"
+														width="12"
+														height="12"
+													>
+														<path
+															d="M7,24a1,1,0,0,1-.71-.29,1,1,0,0,1,0-1.42l8.17-8.17a3,3,0,0,0,0-4.24L6.29,1.71A1,1,0,0,1,7.71.29l8.17,8.17a5,5,0,0,1,0,7.08L7.71,23.71A1,1,0,0,1,7,24Z"
+														/>
+													</svg>
 												</div>
 											</div>
-										</div>
-										<div class="flex items-center justify-between min-w-[77px] ml-4">
-											<div class="flex flex-col items-center flex-nowrap">
-												{#if post.closed}
-													<div class="badge badge-neutral whitespace-nowrap">구했어유</div>
+											<div class="card-body pt-1">
+												{#if post.mainImageUrl}
+													<!-- 메인 이미지가 존재하는 경우 -->
+													<div class="flex">
+														<div class="flex flex-col">
+															<img
+																src={post.mainImageUrl}
+																alt={post.title}
+																class="w-20 h-20 object-cover mb-1"
+															/>
+															<div class="flex mb-2">
+																<div class="flex flex-col items-center mr-2">
+																	<div class="text-xs mx-2 flex justify-center items-center">
+																		{post.incrementViewCount}
+																	</div>
+																	<div class="text-xs text-gray-500">봤어유</div>
+																</div>
+																<div class="flex flex-col items-center mr-2">
+																	<div class="text-xs mx-2 flex justify-center items-center">
+																		{post.commentsCount}
+																	</div>
+																	<div class="text-xs text-gray-500">쑥덕쑥덕</div>
+																</div>
+																<div class="flex flex-col items-center">
+																	<div class="text-xs mx-2 flex justify-center items-center">
+																		{post.interestsCount}
+																	</div>
+																	<div class="text-xs text-gray-500">관심있슈</div>
+																</div>
+															</div>
+														</div>
+														<div class="flex flex-col flex-1">
+															<div class="text-xl font-bold line-clamp-2">
+																{post.title}
+															</div>
+															<div class="flex items-center justify-between mt-2">
+																<div class="flex flex-col items-center flex-nowrap ml-auto">
+																	{#if post.closed}
+																		<div class="badge badge-neutral whitespace-nowrap">
+																			구했어유
+																		</div>
+																	{:else}
+																		<div class="badge badge-primary my-1 whitespace-nowrap">
+																			구해유
+																		</div>
+																		<div class="text-xs text-gray-500 whitespace-nowrap">
+																			~ {post.deadLine}
+																		</div>
+																	{/if}
+																</div>
+															</div>
+														</div>
+													</div>
 												{:else}
-													<div class="badge badge-primary my-1 whitespace-nowrap">구해유</div>
-													<div class="text-xs text-gray-500 whitespace-nowrap">
-														~ {post.deadLine}
+													<!-- 메인 이미지가 존재하지 않는 경우 -->
+													<div class="flex items-center justify-between">
+														<div
+															class="flex flex-col max-40 sm:max-w-sm md:max-w-md lg:max-w-lg xl:max-w-xl overflow-hidden"
+														>
+															<div class="text-xl font-bold max-w-full line-clamp-2">
+																{post.title}
+															</div>
+															<div class="flex mt-2">
+																<div class="flex-shrink">
+																	<div class="text-xs mx-2 flex justify-center items-center">
+																		{post.incrementViewCount}
+																	</div>
+																	<div class="text-xs text-gray-500">봤어유</div>
+																</div>
+																<div class="flex-shrink ml-3">
+																	<div class="text-xs mx-2 flex justify-center items-center">
+																		{post.commentsCount}
+																	</div>
+																	<div class="text-xs text-gray-500">쑥덕쑥덕</div>
+																</div>
+																<div class="flex-shrink ml-3">
+																	<div class="text-xs mx-2 flex justify-center items-center">
+																		{post.interestsCount}
+																	</div>
+																	<div class="text-xs text-gray-500">관심있슈</div>
+																</div>
+															</div>
+														</div>
+														<div class="flex items-center justify-between min-w-[77px] ml-4">
+															<div class="flex flex-col items-center flex-nowrap">
+																{#if post.closed}
+																	<div class="badge badge-neutral whitespace-nowrap">구했어유</div>
+																{:else}
+																	<div class="badge badge-primary my-1 whitespace-nowrap">
+																		구해유
+																	</div>
+																	<div class="text-xs text-gray-500 whitespace-nowrap">
+																		~ {post.deadLine}
+																	</div>
+																{/if}
+															</div>
+														</div>
 													</div>
 												{/if}
 											</div>
 										</div>
-									</div>
-								</div>
+									</a>
+								{/each}
 							</div>
-						</a>
-					{/each}
+							<div class="flex justify-center mt-4">
+								<Pagination {currentPage} {totalPages} on:pageChange={handlePageChange} />
+							</div>
+						{/if}
+					</div>
 				</div>
-			{/if}
+			</div>
 		</div>
-	</div>
-{/await}
+	{/if}
+</div>
 
 <style>
 	.menu details[open] > summary {

--- a/front/src/routes/job-post/list/+page.svelte
+++ b/front/src/routes/job-post/list/+page.svelte
@@ -84,7 +84,7 @@
 	<div class="flex justify-center min-h-screen bg-base-100">
 		<div class="container mx-auto px-4">
 			<div class="w-full max-w-4xl mx-auto">
-				<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+				<div class="grid grid-cols-1 md:grid-cols-2 gap-3">
 					{#each posts ?? [] as post, index}
 						<a href="/job-post/{post.id}" class="block">
 							<div class="card relative bg-base-100 shadow-xl my-4">
@@ -108,16 +108,57 @@
 									</div>
 								</div>
 								<div class="card-body pt-1">
-									<div class="flex items-center justify-between">
-										<div class="flex items-center">
-											<!-- 메인 이미지가 존재하는 경우 -->
-											{#if post.mainImageUrl}
+									{#if post.mainImageUrl}
+										<!-- 메인 이미지가 존재하는 경우 -->
+										<div class="flex">
+											<div class="flex flex-col">
 												<img
 													src={post.mainImageUrl}
 													alt={post.title}
-													class="mr-4 w-20 h-20 object-cover"
+													class="w-20 h-20 object-cover mb-1"
 												/>
-											{/if}
+												<div class="flex mb-2">
+													<div class="flex flex-col items-center mr-2">
+														<div class="text-xs mx-2 flex justify-center items-center">
+															{post.incrementViewCount}
+														</div>
+														<div class="text-xs text-gray-500">봤어유</div>
+													</div>
+													<div class="flex flex-col items-center mr-2">
+														<div class="text-xs mx-2 flex justify-center items-center">
+															{post.commentsCount}
+														</div>
+														<div class="text-xs text-gray-500">쑥덕쑥덕</div>
+													</div>
+													<div class="flex flex-col items-center">
+														<div class="text-xs mx-2 flex justify-center items-center">
+															{post.interestsCount}
+														</div>
+														<div class="text-xs text-gray-500">관심있슈</div>
+													</div>
+												</div>
+											</div>
+											<div class="flex flex-col flex-1">
+												<div class="text-xl font-bold line-clamp-2">
+													{post.title}
+												</div>
+												<div class="flex items-center justify-between mt-2">
+													<div class="flex flex-col items-center flex-nowrap ml-auto">
+														{#if post.closed}
+															<div class="badge badge-neutral whitespace-nowrap">구했어유</div>
+														{:else}
+															<div class="badge badge-primary my-1 whitespace-nowrap">구해유</div>
+															<div class="text-xs text-gray-500 whitespace-nowrap">
+																~ {post.deadLine}
+															</div>
+														{/if}
+													</div>
+												</div>
+											</div>
+										</div>
+									{:else}
+										<!-- 메인 이미지가 존재하지 않는 경우 -->
+										<div class="flex items-center justify-between">
 											<div
 												class="flex flex-col max-40 sm:max-w-sm md:max-w-md lg:max-w-lg xl:max-w-xl overflow-hidden"
 											>
@@ -145,20 +186,20 @@
 													</div>
 												</div>
 											</div>
-										</div>
-										<div class="flex items-center justify-between min-w-[77px] ml-4">
-											<div class="flex flex-col items-center flex-nowrap">
-												{#if post.closed}
-													<div class="badge badge-neutral whitespace-nowrap">구했어유</div>
-												{:else}
-													<div class="badge badge-primary my-1 whitespace-nowrap">구해유</div>
-													<div class="text-xs text-gray-500 whitespace-nowrap">
-														~ {post.deadLine}
-													</div>
-												{/if}
+											<div class="flex items-center justify-between min-w-[77px] ml-4">
+												<div class="flex flex-col items-center flex-nowrap">
+													{#if post.closed}
+														<div class="badge badge-neutral whitespace-nowrap">구했어유</div>
+													{:else}
+														<div class="badge badge-primary my-1 whitespace-nowrap">구해유</div>
+														<div class="text-xs text-gray-500 whitespace-nowrap">
+															~ {post.deadLine}
+														</div>
+													{/if}
+												</div>
 											</div>
 										</div>
-									</div>
+									{/if}
 								</div>
 							</div>
 						</a>

--- a/front/src/routes/job-post/modify/[id]/+page.svelte
+++ b/front/src/routes/job-post/modify/[id]/+page.svelte
@@ -15,9 +15,10 @@
 		workTime: '',
 		workDays: '',
 		cost: '',
-		category: ''
+		categoryId: ''
 	};
 	let postId;
+	let subCategories = []; // 하위 카테고리 목록 저장
 
 	onMount(async () => {
 		postId = parseInt($page.params.id);
@@ -26,6 +27,14 @@
 			console.log('Valid postId, loading job post detail...');
 			await loadJobPostDetail(postId);
 		}
+
+		// 하위 카테고리 로드
+		const params = new URLSearchParams({
+			category_name: '업무'
+		}).toString();
+
+		const response = await rq.apiEndPoints().GET(`/api/categories/sub-categories?${params}`);
+		subCategories = response.data.data;
 	});
 
 	async function loadJobPostDetail(postId) {
@@ -144,19 +153,20 @@
 						bind:value={jobPostData.jobStartDate}
 					/>
 				</div>
+
 				<div class="divider mt-10"></div>
-				<div class="form-group flex-1">
-					<label class="label" for="category">* 카테고리</label>
-					<select class="input input-bordered w-full" id="gender" bind:value={jobPostData.category}>
+
+				<div class="form-group">
+					<label class="label" for="category">* 카테고리 선택</label>
+					<select
+						class="input input-bordered w-full"
+						id="category"
+						bind:value={jobPostData.categoryId}
+					>
 						<option value="" disabled selected>- 선택하세요 -</option>
-						<option value="PERSONAL_ASSISTANCE">일상 도움</option>
-						<option value="CLEANING_AND_ORGANIZATION">정리 및 청소</option>
-						<option value="LOGISTICS_AND_DELIVERY">물류 및 배송</option>
-						<option value="TECHNICAL_TASKS">기술 작업</option>
-						<option value="STORE_MANAGEMENT">매장</option>
-						<option value="OFFICE_AND_EDUCATION">사무 및 교육</option>
-						<option value="EVENT_SUPPORT">행사</option>
-						<option value="OTHERS">(기타)</option>
+						{#each subCategories as category}
+							<option value={category.id}>{category.name}</option>
+						{/each}
 					</select>
 				</div>
 				<div class="form-group">

--- a/front/src/routes/job-post/search/+page.svelte
+++ b/front/src/routes/job-post/search/+page.svelte
@@ -81,7 +81,7 @@
 						<span class="loading loading-dots loading-lg"></span>
 					</div>
 				{:then { data: posts }}
-					<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+					<div class="grid grid-cols-1 md:grid-cols-2 gap-3">
 						{#each posts ?? [] as post, index}
 							<a href="/job-post/{post.id}" class="block">
 								<div class="card relative bg-base-100 shadow-xl my-4">
@@ -103,65 +103,99 @@
 											>
 										</div>
 									</div>
-									<!-- 메인 이미지가 존재하는 경우 -->
-									{#if post.mainImageUrl}
-										<div
-											class="relative bg-cover bg-center h-60"
-											style="background-image: url('{post.mainImageUrl}')"
-										>
-											<div
-												class="absolute inset-0 bg-black bg-opacity-25 flex items-center justify-center"
-											>
-												<div class="text-white text-2xl text-shadow p-4">{post.title}</div>
-											</div>
-										</div>
-									{/if}
-									<div class="card-body {post.mainImageUrl ? '' : 'pt-1'}">
-										<div class="flex items-center justify-between">
-											<div class="flex items-center">
-												<div class="flex flex-col mr-10">
-													<div
-														class="flex flex-col max-w-40 sm:max-w-sm md:max-w-md lg:max-w-lg xl:max-w-xl overflow-hidden"
-													>
-														<div class="text-xl font-bold max-w-full line-clamp-2">
-															{post.title}
+									<div class="card-body pt-1">
+										<!-- 메인 이미지가 존재하는 경우 -->
+										{#if post.mainImageUrl}
+											<div class="flex">
+												<div class="flex flex-col">
+													<img
+														src={post.mainImageUrl}
+														alt={post.title}
+														class="w-20 h-20 object-cover mb-1"
+													/>
+													<div class="flex mb-2">
+														<div class="flex flex-col items-center mr-2">
+															<div class="text-xs mx-2 flex justify-center items-center">
+																{post.incrementViewCount}
+															</div>
+															<div class="text-xs text-gray-500">봤어유</div>
 														</div>
-														<div class="flex mt-2">
-															<div class="flex-shrink">
-																<div class="text-xs mx-2 flex justify-center items-center">
-																	{post.incrementViewCount}
-																</div>
-																<div class="text-xs text-gray-500">봤어유</div>
+														<div class="flex flex-col items-center mr-2">
+															<div class="text-xs mx-2 flex justify-center items-center">
+																{post.commentsCount}
 															</div>
-															<div class="flex-shrink ml-3">
-																<div class="text-xs mx-2 flex justify-center items-center">
-																	{post.commentsCount}
-																</div>
-																<div class="text-xs text-gray-500">쑥덕쑥덕</div>
+															<div class="text-xs text-gray-500">쑥덕쑥덕</div>
+														</div>
+														<div class="flex flex-col items-center">
+															<div class="text-xs mx-2 flex justify-center items-center">
+																{post.interestsCount}
 															</div>
-															<div class="flex-shrink ml-3">
-																<div class="text-xs mx-2 flex justify-center items-center">
-																	{post.interestsCount}
+															<div class="text-xs text-gray-500">관심있슈</div>
+														</div>
+													</div>
+												</div>
+												<div class="flex flex-col flex-1">
+													<div class="text-xl font-bold line-clamp-2">
+														{post.title}
+													</div>
+													<div class="flex items-center justify-between mt-2">
+														<div class="flex flex-col items-center flex-nowrap ml-auto">
+															{#if post.closed}
+																<div class="badge badge-neutral whitespace-nowrap">구했어유</div>
+															{:else}
+																<div class="badge badge-primary my-1 whitespace-nowrap">구해유</div>
+																<div class="text-xs text-gray-500 whitespace-nowrap">
+																	~ {post.deadLine}
 																</div>
-																<div class="text-xs text-gray-500">관심있슈</div>
-															</div>
+															{/if}
 														</div>
 													</div>
 												</div>
 											</div>
-											<div class="flex items-center justify-between min-w-[77px] ml-4">
-												<div class="flex flex-col items-center flex-nowrap">
-													{#if post.closed}
-														<div class="badge badge-neutral whitespace-nowrap">구했어유</div>
-													{:else}
-														<div class="badge badge-primary my-1 whitespace-nowrap">구해유</div>
-														<div class="text-xs text-gray-500 whitespace-nowrap">
-															~ {post.deadLine}
+										{:else}
+											<!-- 메인 이미지가 존재하지 않는 경우 -->
+											<div class="flex items-center justify-between">
+												<div
+													class="flex flex-col max-40 sm:max-w-sm md:max-w-md lg:max-w-lg xl:max-w-xl overflow-hidden"
+												>
+													<div class="text-xl font-bold max-w-full line-clamp-2">
+														{post.title}
+													</div>
+													<div class="flex mt-2">
+														<div class="flex-shrink">
+															<div class="text-xs mx-2 flex justify-center items-center">
+																{post.incrementViewCount}
+															</div>
+															<div class="text-xs text-gray-500">봤어유</div>
 														</div>
-													{/if}
+														<div class="flex-shrink ml-3">
+															<div class="text-xs mx-2 flex justify-center items-center">
+																{post.commentsCount}
+															</div>
+															<div class="text-xs text-gray-500">쑥덕쑥덕</div>
+														</div>
+														<div class="flex-shrink ml-3">
+															<div class="text-xs mx-2 flex justify-center items-center">
+																{post.interestsCount}
+															</div>
+															<div class="text-xs text-gray-500">관심있슈</div>
+														</div>
+													</div>
+												</div>
+												<div class="flex items-center justify-between min-w-[77px] ml-4">
+													<div class="flex flex-col items-center flex-nowrap">
+														{#if post.closed}
+															<div class="badge badge-neutral whitespace-nowrap">구했어유</div>
+														{:else}
+															<div class="badge badge-primary my-1 whitespace-nowrap">구해유</div>
+															<div class="text-xs text-gray-500 whitespace-nowrap">
+																~ {post.deadLine}
+															</div>
+														{/if}
+													</div>
 												</div>
 											</div>
-										</div>
+										{/if}
 									</div>
 								</div>
 							</a>


### PR DESCRIPTION
## 변경 내용

### 1. 카테고리 테이블 연관관계 수정

기존의 job_post와 category의 N:1 매핑 관계를 중간 테이블(job_post_category)를 이용해 N:M 으로 변경 <br/><br/>

(변경 전)
![image](https://github.com/user-attachments/assets/861638ef-ad5d-4ac9-bf70-0cfbb3abe6f4)

(변경 후)
![image](https://github.com/user-attachments/assets/c8e03159-3c1b-4d8a-9eb7-4a0cd39daa3a)

<br/><br/>

### 2. categoryType Enum 클래스 추가해서 category 엔티티에 필드로 추가
- 현재는 'TASK', 'REGION' 만 추가

---
### 3. 공고글 작성 시 JobPostCategory 객체가 생성되도록 설정

### 4. 공고 수정 메서드에 JobPostCategory 업데이트 로직 추가 및 코드 리팩토링

### 5. 공고글 삭제 시 해당 글의 JobPostCategory 객체들도 같이 삭제되도록 설정
---

<br/>

### 6. 카테고리의 글 불러오기 기능 수정 (카테고리id에 해당하는 공고글 페이지를 불러오는 쿼리메서드 추가)
```java
@Repository
public interface JobPostCategoryRepository extends JpaRepository<JobPostCategory, Long> {
    @Query("SELECT jpc.jobPost FROM JobPostCategory jpc WHERE jpc.category.id = :categoryId ORDER BY jpc.jobPost.createdAt DESC")
    Page<JobPost> findJobPostsByCategoryId(@Param("categoryId") Long categoryId, Pageable pageable);
```

<br/>

### 7. 프론트 작업
- CategoryPagination.svelte 추가
- 기존 페이지 이동 버튼 색상 수정
- 카테고리 페이지 전체적인 수정
- 기존 글목록 관련 페이지 레이아웃 수정
   - 글 목록에서 이미지가 있는 글 레이아웃 수정
   - 글 목록에서 글 간격을 4에서 3으로 줄임

<br/>

### 8. README 수정 <br/><br/>