### PR TITLE
refactor: 채팅방에서 상대방 프로필 이미지 처리  방법 변경

### DIFF
--- a/back/src/main/java/com/ll/goohaeyou/chat/message/application/dto/MessageDto.java
+++ b/back/src/main/java/com/ll/goohaeyou/chat/message/application/dto/MessageDto.java
@@ -18,7 +18,6 @@ public class MessageDto {
     @NotNull
     private String text;
     private String createdAt;
-    private String profileImageUrl;
 
     public static MessageDto from(Message message) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm");
@@ -27,7 +26,6 @@ public class MessageDto {
                 .sender(message.getSender())
                 .text(message.getContent())
                 .createdAt(message.getCreatedAt().format(formatter))
-                .profileImageUrl(message.getProfileImageUrl())
                 .build();
     }
 

--- a/back/src/main/java/com/ll/goohaeyou/chat/message/domain/entity/Message.java
+++ b/back/src/main/java/com/ll/goohaeyou/chat/message/domain/entity/Message.java
@@ -26,32 +26,26 @@ public class Message {
 
     private LocalDateTime createdAt;
 
-    private String profileImageUrl;
-
     private Message(
             Room room,
             String sender,
-            String content,
-            String profileImageUrl
+            String content
     ) {
         this.room = room;
         this.sender = sender;
         this.content = content;
         this.createdAt = LocalDateTime.now();
-        this.profileImageUrl = profileImageUrl;
     }
 
     public static Message createBasic(
             Room room,
             String sender,
-            String content,
-            String profileImageUrl
+            String content
     ) {
         return new Message(
                 room,
                 sender,
-                content,
-                profileImageUrl
+                content
         );
     }
 
@@ -63,8 +57,7 @@ public class Message {
         return new Message(
                 room,
                 sender,
-                content,
-                null
+                content
         );
     }
 

--- a/back/src/main/java/com/ll/goohaeyou/chat/message/domain/service/MessageDomainService.java
+++ b/back/src/main/java/com/ll/goohaeyou/chat/message/domain/service/MessageDomainService.java
@@ -22,7 +22,7 @@ public class MessageDomainService {
 
     @Transactional
     public Message create(Room room, String username, String content, String profileImageUrl) {
-        Message newMessage = Message.createBasic(room, username, content, profileImageUrl);
+        Message newMessage = Message.createBasic(room, username, content);
         room.getMessages().add(newMessage);
 
         return messageRepository.save(newMessage);

--- a/back/src/main/java/com/ll/goohaeyou/chat/room/application/RoomService.java
+++ b/back/src/main/java/com/ll/goohaeyou/chat/room/application/RoomService.java
@@ -39,10 +39,11 @@ public class RoomService {
 
     public RoomDto findById(Long roomId, String username) {
         Room room = roomDomainService.getById(roomId);
+        Member member1 = memberDomainService.getByUsername(username);
 
         roomPolicy.verifyRoomAccess(username, room);
 
-        return RoomDto.from(room);
+        return RoomDto.from(room, member1.getProfileImageUrl());
     }
 
     public List<RoomListDto> getRoomList(String username) {

--- a/back/src/main/java/com/ll/goohaeyou/chat/room/application/dto/RoomDto.java
+++ b/back/src/main/java/com/ll/goohaeyou/chat/room/application/dto/RoomDto.java
@@ -2,29 +2,21 @@ package com.ll.goohaeyou.chat.room.application.dto;
 
 import com.ll.goohaeyou.chat.message.domain.entity.Message;
 import com.ll.goohaeyou.chat.room.domain.entity.Room;
-import lombok.Builder;
-import lombok.Getter;
 
 import java.util.List;
 
-@Getter
-@Builder
-public class RoomDto {
-    private String username1;
-    private String username2;
-    private List<Message> messages;
-
-    public static RoomDto from(Room room) {
-        return RoomDto.builder()
-                .username1(room.getUsername1())
-                .username2(room.getUsername2())
-                .messages(room.getMessages())
-                .build();
-    }
-
-    public static List<RoomDto> convertToDtoList(List<Room> rooms) {
-        return rooms.stream()
-                .map(RoomDto::from)
-                .toList();
+public record RoomDto(
+        String username1,
+        String username2,
+        List<Message> messages,
+        String user1ImageUrl
+) {
+    public static RoomDto from(Room room, String user1ImageUrl) {
+        return new RoomDto(
+                room.getUsername1(),
+                room.getUsername2(),
+                room.getMessages(),
+                user1ImageUrl
+        );
     }
 }

--- a/back/src/main/java/com/ll/goohaeyou/chat/room/application/dto/RoomListDto.java
+++ b/back/src/main/java/com/ll/goohaeyou/chat/room/application/dto/RoomListDto.java
@@ -1,30 +1,26 @@
 package com.ll.goohaeyou.chat.room.application.dto;
 
 import com.ll.goohaeyou.chat.room.domain.entity.Room;
-import lombok.Builder;
-import lombok.Getter;
 
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
-@Getter
-@Builder
-public class RoomListDto {
-    private Long roomId;
-    private String username1;
-    private String username2;
-    private String lastChat;
-    private String lastChatDate;
-
+public record RoomListDto(
+        Long roomId,
+        String username1,
+        String username2,
+        String lastChat,
+        String lastChatDate
+) {
     public static RoomListDto from(Room room) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm");
-        return RoomListDto.builder()
-                .roomId(room.getId())
-                .username1(room.getUsername1())
-                .username2(room.getUsername2())
-                .lastChat(room.getMessages().isEmpty() ? "메세지가 아직 없습니다." : room.getMessages().getLast().getContent())
-                .lastChatDate(room.getMessages().isEmpty() ? "" : room.getMessages().getLast().getCreatedAt().format(formatter))
-                .build();
+        return new RoomListDto(
+                room.getId(),
+                room.getUsername1(),
+                room.getUsername2(),
+                room.getMessages().isEmpty() ? "메세지가 아직 없습니다." : room.getMessages().get(room.getMessages().size() - 1).getContent(),
+                room.getMessages().isEmpty() ? "" : room.getMessages().get(room.getMessages().size() - 1).getCreatedAt().format(formatter)
+        );
     }
 
     public static List<RoomListDto> convertToDtoList(List<Room> rooms) {

--- a/front/src/lib/types/api/v1/schema.d.ts
+++ b/front/src/lib/types/api/v1/schema.d.ts
@@ -1583,17 +1583,17 @@ export interface components {
             /** Format: int64 */
             offset?: number;
             sort?: components["schemas"]["SortObject"];
-            paged?: boolean;
-            unpaged?: boolean;
             /** Format: int32 */
             pageNumber?: number;
             /** Format: int32 */
             pageSize?: number;
+            paged?: boolean;
+            unpaged?: boolean;
         };
         SortObject: {
             empty?: boolean;
-            unsorted?: boolean;
             sorted?: boolean;
+            unsorted?: boolean;
         };
         ApiResponseListJobPostApplicationResponse: {
             /** Format: int32 */
@@ -1653,7 +1653,6 @@ export interface components {
             content?: string;
             /** Format: date-time */
             createdAt?: string;
-            profileImageUrl?: string;
         };
         Room: {
             /** Format: int64 */
@@ -1671,6 +1670,7 @@ export interface components {
             username1?: string;
             username2?: string;
             messages?: components["schemas"]["Message"][];
+            user1ImageUrl?: string;
         };
         ApiResponseListMessageDto: {
             /** Format: int32 */
@@ -1687,7 +1687,6 @@ export interface components {
             sender: string;
             text: string;
             createdAt?: string;
-            profileImageUrl?: string;
         };
         ApiResponseListSubCategoryResponse: {
             /** Format: int32 */

--- a/front/src/routes/chat/[id]/+page.svelte
+++ b/front/src/routes/chat/[id]/+page.svelte
@@ -16,6 +16,7 @@
 	let chatMessagesEl;
 	const member = rq.member;
 	let messages = [];
+	let user1ProfileImageUrl = '';
 
 	onMount(async () => {
 		await rq.initAuth();
@@ -46,6 +47,8 @@
 	async function load() {
 		const { data } = await rq.apiEndPoints().GET(`/api/chat/${roomId}`);
 		lastMessageId = data?.data?.messages[0]?.id;
+		user1ProfileImageUrl = data?.data?.user1ImageUrl;
+
 		return data!;
 	}
 
@@ -176,8 +179,8 @@
 										<div
 											class="bg-neutral text-neutral-content rounded-full w-12 border-2 border-gray"
 										>
-											{#if message.profileImageUrl != null}
-												<img src={message.profileImageUrl} alt="프로필 사진" />
+											{#if user1ProfileImageUrl != null}
+												<img src={user1ProfileImageUrl} alt="프로필 사진" />
 											{:else}
 												<span class="text-xs">{message.sender.slice(0, 4)}</span>
 											{/if}


### PR DESCRIPTION
## 작업 내용

### 채팅방에서 상대방 프로필 이미지 처리 변경

- 기존 프로필 이미지 URL을 Message의 필드에 저장하여 Dto로 넘겨주는 방식에서 RoomDto에 저장하는 방식으로 변경
  - RoomDto에 상대방의 프로필 이미지 URL을 저장할 수 있는 user1ImageUrl 필드를 추가하고, 클래스를 record로 변경하여 불변성 보장
  - Message, MessageDto에서 더 이상 필요하지 않은 profileImageUrl 필드 제거
- RoomListDto를 record로 변경하여 불변성을 보장